### PR TITLE
Fix(integration): Signer arguments no longer needed in ERC-20 queries

### DIFF
--- a/.github/workflows/clippy_check.yaml
+++ b/.github/workflows/clippy_check.yaml
@@ -20,9 +20,11 @@ jobs:
         - uses: actions/checkout@v4
         - uses: actions-rs/toolchain@v1
           with:
+            default: true
             toolchain: stable
             components: clippy
-            default: true
+        - name: Free up disk space
+          run: rm -rf /opt/hostedtoolcache
         - uses: actions-rs/clippy-check@v1
           with:
             token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clippy_check.yaml
+++ b/.github/workflows/clippy_check.yaml
@@ -18,13 +18,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4
-        - uses: actions-rs/toolchain@v1
-          with:
-            default: true
-            toolchain: stable
-            components: clippy
-        - name: Free up disk space
-          run: rm -rf /opt/hostedtoolcache
+        - run: rustup component add clippy
         - uses: actions-rs/clippy-check@v1
           with:
             token: ${{ secrets.GITHUB_TOKEN }}

--- a/server/src/tests/integration/erc20.rs
+++ b/server/src/tests/integration/erc20.rs
@@ -215,10 +215,6 @@ pub async fn l2_erc20_balance_of(token: Address, account: Address, rpc_url: &str
     let provider = ProviderBuilder::new().on_http(Url::parse(rpc_url)?);
 
     let args = vec![
-        // The caller here does not matter because it is a view call.
-        MoveValue::Signer(EVM_NATIVE_ADDRESS)
-            .simple_serialize()
-            .unwrap(),
         MoveValue::Address(token.to_move_address())
             .simple_serialize()
             .unwrap(),
@@ -262,10 +258,6 @@ pub async fn l2_erc20_allowance(
     let provider = ProviderBuilder::new().on_http(Url::parse(rpc_url)?);
 
     let args = vec![
-        // The caller here does not matter because it is a view call.
-        MoveValue::Signer(EVM_NATIVE_ADDRESS)
-            .simple_serialize()
-            .unwrap(),
         MoveValue::Address(token.to_move_address())
             .simple_serialize()
             .unwrap(),


### PR DESCRIPTION
### Description
I realized I accidentally broke the integration test in #358 because I forgot to remove the signer argument from the ERC-20 queries constructed in the integration test. This PR fixes the problem so the integration test passes again.

### Changes
- No production code changes

### Testing
- Integration test
