### PR TITLE
refactor(storage): Replace all `State` implementations with `EthTrieState`

### DIFF
--- a/server/src/dependency/heed.rs
+++ b/server/src/dependency/heed.rs
@@ -2,7 +2,7 @@ use {
     crate::dependency::shared::*,
     moved_app::{Application, ApplicationReader, CommandActor},
     moved_genesis::config::GenesisConfig,
-    moved_state::State,
+    moved_state::{EthTrieState, State},
     moved_storage_heed::{
         block, evm, evm_storage_trie, heed::EnvOpenOptions, payload, receipt, state, transaction,
         trie,
@@ -38,7 +38,7 @@ impl moved_app::Dependencies for HeedDependencies {
     type SharedStorage = &'static moved_storage_heed::Env;
     type ReceiptStorageReader = &'static moved_storage_heed::Env;
     type SharedStorageReader = &'static moved_storage_heed::Env;
-    type State = state::HeedState<'static>;
+    type State = EthTrieState<trie::HeedEthTrieDb<'static>>;
     type StateQueries = state::HeedStateQueries<'static>;
     type StorageTrieRepository = evm::HeedStorageTrieRepository;
     type TransactionQueries = transaction::HeedTransactionQueries;
@@ -98,7 +98,7 @@ impl moved_app::Dependencies for HeedDependencies {
     }
 
     fn state(&self) -> Self::State {
-        state::HeedState::new(TRIE_DB.clone())
+        EthTrieState::try_new(TRIE_DB.clone()).unwrap()
     }
 
     fn state_queries(&self, genesis_config: &GenesisConfig) -> Self::StateQueries {

--- a/server/src/dependency/rocksdb.rs
+++ b/server/src/dependency/rocksdb.rs
@@ -2,7 +2,7 @@ use {
     crate::dependency::shared::*,
     moved_app::{Application, ApplicationReader, CommandActor},
     moved_genesis::config::GenesisConfig,
-    moved_state::State,
+    moved_state::{EthTrieState, State},
 };
 
 pub type Dependency = RocksDbDependencies;
@@ -34,7 +34,7 @@ impl moved_app::Dependencies for RocksDbDependencies {
     type SharedStorage = &'static moved_storage_rocksdb::RocksDb;
     type ReceiptStorageReader = &'static moved_storage_rocksdb::RocksDb;
     type SharedStorageReader = &'static moved_storage_rocksdb::RocksDb;
-    type State = moved_storage_rocksdb::RocksDbState<'static>;
+    type State = EthTrieState<moved_storage_rocksdb::RocksEthTrieDb<'static>>;
     type StateQueries = moved_storage_rocksdb::RocksDbStateQueries<'static>;
     type StorageTrieRepository = moved_storage_rocksdb::evm::RocksDbStorageTrieRepository;
     type TransactionQueries = moved_storage_rocksdb::transaction::RocksDbTransactionQueries;
@@ -94,7 +94,7 @@ impl moved_app::Dependencies for RocksDbDependencies {
     }
 
     fn state(&self) -> Self::State {
-        moved_storage_rocksdb::RocksDbState::new(TRIE_DB.clone())
+        EthTrieState::try_new(TRIE_DB.clone()).unwrap()
     }
 
     fn state_queries(&self, genesis_config: &GenesisConfig) -> Self::StateQueries {

--- a/storage/heed/src/trie.rs
+++ b/storage/heed/src/trie.rs
@@ -5,6 +5,7 @@ use {
     },
     eth_trie::{DB, EthTrie, TrieError},
     heed::RoTxn,
+    moved_evm_ext::state::DbWithRoot,
     moved_shared::primitives::B256,
     std::sync::Arc,
 };
@@ -27,8 +28,10 @@ impl<'db> HeedEthTrieDb<'db> {
     pub fn new(env: &'db heed::Env) -> Self {
         Self { env }
     }
+}
 
-    pub fn root(&self) -> Result<Option<B256>, heed::Error> {
+impl DbWithRoot for HeedEthTrieDb<'_> {
+    fn root(&self) -> Result<Option<B256>, heed::Error> {
         let transaction = self.env.read_txn()?;
 
         let db = self.env.trie_root_database(&transaction)?;
@@ -40,7 +43,7 @@ impl<'db> HeedEthTrieDb<'db> {
         Ok(root)
     }
 
-    pub fn put_root(&self, root: B256) -> Result<(), heed::Error> {
+    fn put_root(&self, root: B256) -> Result<(), heed::Error> {
         let mut transaction = self.env.write_txn()?;
 
         let db = self.env.trie_root_database(&transaction)?;

--- a/storage/rocksdb/src/lib.rs
+++ b/storage/rocksdb/src/lib.rs
@@ -13,6 +13,6 @@ pub use {
     all::COLUMN_FAMILIES,
     block::RocksDbBlockRepository,
     rocksdb::{self, DB as RocksDb},
-    state::{RocksDbState, RocksDbStateQueries},
+    state::RocksDbStateQueries,
     trie::{ROOT_KEY, RocksEthTrieDb},
 };

--- a/storage/rocksdb/src/trie.rs
+++ b/storage/rocksdb/src/trie.rs
@@ -1,5 +1,6 @@
 use {
     eth_trie::{DB, EthTrie, TrieError},
+    moved_evm_ext::state::DbWithRoot,
     moved_shared::primitives::B256,
     rocksdb::{AsColumnFamilyRef, DB as RocksDb, WriteBatchWithTransaction},
     std::sync::Arc,
@@ -18,17 +19,6 @@ impl<'db> RocksEthTrieDb<'db> {
         Self { db }
     }
 
-    pub fn root(&self) -> Result<Option<B256>, rocksdb::Error> {
-        Ok(self
-            .db
-            .get_cf(self.root_cf(), ROOT_KEY)?
-            .map(|v| B256::new(v.try_into().unwrap())))
-    }
-
-    pub fn put_root(&self, root: B256) -> Result<(), rocksdb::Error> {
-        self.db.put_cf(self.root_cf(), ROOT_KEY, root.as_slice())
-    }
-
     fn cf(&self) -> &impl AsColumnFamilyRef {
         self.db
             .cf_handle(TRIE_COLUMN_FAMILY)
@@ -39,6 +29,19 @@ impl<'db> RocksEthTrieDb<'db> {
         self.db
             .cf_handle(ROOT_COLUMN_FAMILY)
             .expect("Column family should exist")
+    }
+}
+
+impl DbWithRoot for RocksEthTrieDb<'_> {
+    fn root(&self) -> Result<Option<B256>, rocksdb::Error> {
+        Ok(self
+            .db
+            .get_cf(self.root_cf(), ROOT_KEY)?
+            .map(|v| B256::new(v.try_into().unwrap())))
+    }
+
+    fn put_root(&self, root: B256) -> Result<(), rocksdb::Error> {
+        self.db.put_cf(self.root_cf(), ROOT_KEY, root.as_slice())
     }
 }
 

--- a/storage/rocksdb/tests/collision.rs
+++ b/storage/rocksdb/tests/collision.rs
@@ -1,6 +1,7 @@
 use {
     eth_trie::DB,
     hex_literal::hex,
+    moved_evm_ext::state::DbWithRoot,
     moved_shared::primitives::B256,
     moved_storage_rocksdb::{ROOT_KEY, RocksEthTrieDb},
 };


### PR DESCRIPTION
# About
Implements the proposed model below using a `State` implementation backed by `EthTrie`.

# Motivation
The storage layer should not contain any domain logic. A practical consequence of this is duplicated code, heavier maintenance burden and more complicated storage implementations.

# Problem
The blockchain `State` is a trie structure, therefore it relies a lot on trie algorithms. When having multiple implementations, the only difference is the underlying key-value store. However, implementing `State` per storage engine requires to provide both key-value store and trie algorithms.

The result is that every `State` implementation duplicates knowledge that belongs in the domain layer.

```mermaid
---
title: Current model
---
classDiagram
    State <|-- HeedState
    State <|-- RocksDbState
    State <|-- InMemoryState
    class State
        <<trait>> State
    class RocksDbState
        <<struct>> RocksDbState
    class HeedState
        <<struct>> HeedState
    class InMemoryState
        <<struct>> InMemoryState
```

# Solution
Add a single `State` implementation that implements all the functions using `EthTrie` and require only a key-value store implementation.

```mermaid
---
title: Proposed model
---
classDiagram
    DbWithRoot <-- EthTrie
    EthTrie <-- EthTrieResolver
    EthTrieResolver <-- EthTrieState
    State <|-- EthTrieState
    DbWithRoot <|-- HeedTrieDb
    DbWithRoot <|-- RocksTrieDb
    DbWithRoot <|-- InMemoryTrieDb
    class State
        <<trait>> State
    class EthTrieState
        <<struct>> EthTrieState
        EthTrieState : EthTrieResolver resolver
    class EthTrieResolver
        <<struct>> EthTrieResolver
        EthTrieResolver : EthTrie tree
    class EthTrie
        <<struct>> EthTrieState
        EthTrie : DbWithRoot db
    class DbWithRoot
        <<trait>> DbWithRoot
    class HeedTrieDb
        <<struct>> HeedTrieDb
    class RocksTrieDb
        <<struct>> RocksTrieDb
    class InMemoryTrieDb
        <<struct>> InMemoryTrieDb
```
