### PR TITLE
feat(app): ring buffer for the `BLOCKHASH` opcode

### DIFF
--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -33,7 +33,7 @@ mod tests {
         crate::methods::forkchoice_updated,
         alloy::primitives::hex,
         std::sync::Arc,
-        umi_app::{Application, CommandActor, TestDependencies},
+        umi_app::{Application, CommandActor, SharedBlockHashCache, TestDependencies},
         umi_blockchain::{
             block::{
                 Block, BlockRepository, Eip1559GasFee, InMemoryBlockQueries,
@@ -45,7 +45,7 @@ mod tests {
             state::InMemoryStateQueries,
             transaction::{InMemoryTransactionQueries, InMemoryTransactionRepository},
         },
-        umi_evm_ext::state::InMemoryStorageTrieRepository,
+        umi_evm_ext::state::{BlockHashWriter, InMemoryStorageTrieRepository},
         umi_genesis::config::GenesisConfig,
         umi_shared::primitives::{B256, U256},
         umi_state::{InMemoryState, InMemoryTrieDb},
@@ -77,6 +77,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute_v3() {
         let genesis_config = GenesisConfig::default();
+        let mut block_hash_cache = SharedBlockHashCache::default();
 
         // Set known block height
         let head_hash = B256::new(hex!(
@@ -87,6 +88,7 @@ mod tests {
         let (memory_reader, mut memory) = shared_memory::new();
         let mut repository = InMemoryBlockRepository::new();
         repository.add(&mut memory, genesis_block).unwrap();
+        block_hash_cache.push(0, head_hash);
 
         let trie_db = Arc::new(InMemoryTrieDb::empty());
         let mut state = InMemoryState::empty(trie_db.clone());
@@ -108,6 +110,7 @@ mod tests {
             genesis_config: genesis_config.clone(),
             state,
             block_hash: head_hash,
+            block_hash_writer: block_hash_cache.clone(),
             block_repository: repository,
             gas_fee: Eip1559GasFee::default(),
             base_token: (),
@@ -140,6 +143,8 @@ mod tests {
                 _,
                 UmiBlockHash,
                 _,
+                SharedBlockHashCache,
+                _,
                 (),
                 _,
                 _,
@@ -158,6 +163,7 @@ mod tests {
         > {
             genesis_config,
             base_token: (),
+            block_hash_lookup: block_hash_cache,
             block_queries: InMemoryBlockQueries,
             storage: memory_reader.clone(),
             state_queries: InMemoryStateQueries::new(memory_reader, trie_db, genesis_state_root),

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -33,7 +33,7 @@ pub mod tests {
         tokio::sync::mpsc::Sender,
         umi_app::{
             Application, ApplicationReader, Command, CommandActor, DependenciesThreadSafe, Payload,
-            TestDependencies,
+            SharedBlockHashCache, TestDependencies,
         },
         umi_blockchain::{
             block::{
@@ -46,7 +46,7 @@ pub mod tests {
             state::{InMemoryStateQueries, MockStateQueries},
             transaction::{InMemoryTransactionQueries, InMemoryTransactionRepository},
         },
-        umi_evm_ext::state::InMemoryStorageTrieRepository,
+        umi_evm_ext::state::{BlockHashWriter, InMemoryStorageTrieRepository},
         umi_execution::UmiBaseTokenAccounts,
         umi_genesis::config::{CHAIN_ID, GenesisConfig},
         umi_shared::primitives::{Address, B256, U64, U256},
@@ -61,6 +61,7 @@ pub mod tests {
         Application<TestDependencies>,
     ) {
         let genesis_config = GenesisConfig::default();
+        let mut block_hash_cache = SharedBlockHashCache::default();
 
         let head_hash = B256::new(hex!(
             "e56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d"
@@ -76,6 +77,7 @@ pub mod tests {
         let (memory_reader, mut memory) = shared_memory::new();
         let mut repository = InMemoryBlockRepository::new();
         repository.add(&mut memory, genesis_block).unwrap();
+        block_hash_cache.push(0, head_hash);
 
         let trie_db = Arc::new(InMemoryTrieDb::empty());
         let mut state = InMemoryState::empty(trie_db.clone());
@@ -100,6 +102,7 @@ pub mod tests {
             ApplicationReader {
                 genesis_config: genesis_config.clone(),
                 base_token: UmiBaseTokenAccounts::new(AccountAddress::ONE),
+                block_hash_lookup: block_hash_cache.clone(),
                 block_queries: InMemoryBlockQueries,
                 payload_queries: InMemoryPayloadQueries::new(),
                 receipt_queries: InMemoryReceiptQueries::new(),
@@ -117,6 +120,7 @@ pub mod tests {
                 l1_fee: U256::ZERO,
                 l2_fee: U256::ZERO,
                 block_hash: UmiBlockHash,
+                block_hash_writer: block_hash_cache,
                 block_queries: InMemoryBlockQueries,
                 block_repository: repository,
                 on_payload: CommandActor::on_payload_in_memory(),
@@ -246,6 +250,8 @@ pub mod tests {
                     _,
                     UmiBlockHash,
                     _,
+                    SharedBlockHashCache,
+                    _,
                     (),
                     _,
                     _,
@@ -264,6 +270,7 @@ pub mod tests {
             > {
                 genesis_config: GenesisConfig::default(),
                 base_token: UmiBaseTokenAccounts::new(AccountAddress::ONE),
+                block_hash_lookup: (),
                 block_queries: StubLatest(height),
                 payload_queries: (),
                 receipt_queries: (),
@@ -273,7 +280,28 @@ pub mod tests {
                 evm_storage: (),
                 transaction_queries: (),
             },
-            Application::<TestDependencies<_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _>> {
+            Application::<
+                TestDependencies<
+                    _,
+                    _,
+                    _,
+                    _,
+                    SharedBlockHashCache,
+                    _,
+                    _,
+                    _,
+                    _,
+                    _,
+                    _,
+                    _,
+                    _,
+                    _,
+                    _,
+                    _,
+                    _,
+                    _,
+                >,
+            > {
                 genesis_config: GenesisConfig::default(),
                 mem_pool: Default::default(),
                 gas_fee: Eip1559GasFee::default(),
@@ -281,6 +309,7 @@ pub mod tests {
                 l1_fee: U256::ZERO,
                 l2_fee: U256::ZERO,
                 block_hash: UmiBlockHash,
+                block_hash_writer: SharedBlockHashCache::default(),
                 block_queries: StubLatest(height),
                 block_repository: (),
                 on_payload: CommandActor::on_payload_noop(),

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -155,7 +155,9 @@ mod tests {
         crate::methods::{forkchoice_updated, get_payload},
         alloy::primitives::hex,
         std::sync::Arc,
-        umi_app::{Application, CommandActor, TestDependencies},
+        umi_app::{
+            Application, BlockHashRingBuffer, CommandActor, SharedBlockHashCache, TestDependencies,
+        },
         umi_blockchain::{
             block::{
                 Block, BlockRepository, Eip1559GasFee, InMemoryBlockQueries,
@@ -167,7 +169,7 @@ mod tests {
             state::InMemoryStateQueries,
             transaction::{InMemoryTransactionQueries, InMemoryTransactionRepository},
         },
-        umi_evm_ext::state::InMemoryStorageTrieRepository,
+        umi_evm_ext::state::{BlockHashWriter, InMemoryStorageTrieRepository},
         umi_genesis::config::GenesisConfig,
         umi_shared::primitives::{Address, B2048, Bytes, U64, U256},
         umi_state::{InMemoryState, InMemoryTrieDb},
@@ -256,6 +258,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute_v3() {
         let genesis_config = GenesisConfig::default();
+        let mut block_hash_cache = SharedBlockHashCache::default();
 
         // Set known block height
         let head_hash = B256::new(hex!(
@@ -266,6 +269,7 @@ mod tests {
         let (memory_reader, mut memory) = shared_memory::new();
         let mut repository = InMemoryBlockRepository::new();
         repository.add(&mut memory, genesis_block).unwrap();
+        block_hash_cache.push(0, head_hash);
 
         let trie_db = Arc::new(InMemoryTrieDb::empty());
         let mut state = InMemoryState::empty(trie_db.clone());
@@ -292,6 +296,8 @@ mod tests {
             block_hash: B256::from(hex!(
                 "c013e1ff1b8bca9f0d074618cc9e661983bc91d7677168b156765781aee775d3"
             )),
+
+            block_hash_writer: block_hash_cache.clone(),
             block_queries: InMemoryBlockQueries,
             block_repository: repository,
             on_payload: CommandActor::on_payload_in_memory(),
@@ -321,6 +327,8 @@ mod tests {
                 _,
                 UmiBlockHash,
                 _,
+                BlockHashRingBuffer,
+                _,
                 (),
                 _,
                 _,
@@ -339,6 +347,7 @@ mod tests {
         > {
             genesis_config,
             base_token: (),
+            block_hash_lookup: block_hash_cache,
             block_queries: InMemoryBlockQueries,
             storage: memory_reader.clone(),
             state_queries: InMemoryStateQueries::new(memory_reader, trie_db, genesis_state_root),

--- a/app/src/block_hash.rs
+++ b/app/src/block_hash.rs
@@ -1,37 +1,226 @@
 use {
-    alloy::primitives::B256, umi_blockchain::block::BlockQueries,
-    umi_evm_ext::state::BlockHashLookup,
+    alloy::primitives::B256,
+    std::{
+        collections::VecDeque,
+        sync::{Arc, RwLock},
+    },
+    umi_blockchain::block::BlockQueries,
+    umi_evm_ext::state::{BlockHashLookup, BlockHashWriter},
 };
 
-pub struct StorageBasedProvider<'a, S, B> {
-    storage: &'a S,
-    block_query: &'a B,
+const BLOCKHASH_HISTORY_SIZE: usize = 256;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BlockHashEntry {
+    number: u64,
+    hash: B256,
 }
 
-impl<'a, S, B> StorageBasedProvider<'a, S, B>
-where
-    B: BlockQueries<Storage = S>,
-{
-    pub fn new(storage: &'a S, block_query: &'a B) -> Self {
+#[derive(Debug, Clone)]
+pub struct BlockHashRingBuffer {
+    entries: VecDeque<BlockHashEntry>,
+    /// Block number of the latest block stored for validation purposes
+    latest_block: u64,
+}
+
+impl Default for BlockHashRingBuffer {
+    fn default() -> Self {
         Self {
-            storage,
-            block_query,
+            entries: VecDeque::with_capacity(BLOCKHASH_HISTORY_SIZE),
+            latest_block: 0,
         }
     }
 }
 
-// TODO: looking up the entire block just to get its hash is inefficient;
-// especially since we do not need the whole history, only the most recent 256
-// block hashes. This implementation should be replaced with something better.
-impl<S, B> BlockHashLookup for StorageBasedProvider<'_, S, B>
-where
-    B: BlockQueries<Storage = S>,
-{
+impl BlockHashRingBuffer {
+    pub fn push(&mut self, block_number: u64, block_hash: B256) {
+        // Ensure blocks are added in sequence (detect potential reorgs)
+        if block_number > 0 && self.latest_block > 0 && block_number != self.latest_block + 1 {
+            eprintln!(
+                "WARN: Block hash buffer - expected block {}, got {}",
+                self.latest_block + 1,
+                block_number
+            );
+        }
+
+        self.entries.push_back(BlockHashEntry {
+            number: block_number,
+            hash: block_hash,
+        });
+
+        while self.entries.len() > BLOCKHASH_HISTORY_SIZE {
+            self.entries.pop_front();
+        }
+
+        self.latest_block = block_number;
+    }
+
+    // TODO: make this a builder method?
+    pub fn initialize_from_storage<S, B>(&mut self, storage: &S, block_query: &B, latest_block: u64)
+    where
+        B: BlockQueries<Storage = S>,
+    {
+        self.entries.clear();
+        self.latest_block = 0;
+
+        let start_block = if latest_block >= BLOCKHASH_HISTORY_SIZE as u64 {
+            latest_block - BLOCKHASH_HISTORY_SIZE as u64 + 1
+        } else {
+            0
+        };
+
+        for block_num in start_block..=latest_block {
+            if let Ok(Some(block)) = block_query.by_height(storage, block_num, false) {
+                self.push(block_num, block.0.header.hash);
+            }
+        }
+    }
+}
+
+impl BlockHashLookup for BlockHashRingBuffer {
+    fn hash_by_number(&self, block_number: u64) -> Option<B256> {
+        if block_number > self.latest_block {
+            // Future block
+            return None;
+        }
+
+        let blocks_ago = self.latest_block - block_number;
+        if blocks_ago > BLOCKHASH_HISTORY_SIZE as u64 {
+            // Too old
+            return None;
+        }
+
+        for entry in self.entries.iter().rev() {
+            if entry.number == block_number {
+                return Some(entry.hash);
+            }
+            // Since we're going backwards chronologically, if we've passed the target block, it's not there
+            if entry.number < block_number {
+                break;
+            }
+        }
+
+        None
+    }
+}
+
+impl BlockHashWriter for BlockHashRingBuffer {
+    fn push(&mut self, height: u64, hash: B256) {
+        self.push(height, hash);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SharedBlockHashCache {
+    inner: Arc<RwLock<BlockHashRingBuffer>>,
+}
+
+impl SharedBlockHashCache {
+    pub fn initialize_from_storage<S, B>(&mut self, storage: &S, block_query: &B, latest_block: u64)
+    where
+        B: BlockQueries<Storage = S>,
+    {
+        if let Ok(mut cache) = self.inner.write() {
+            cache.initialize_from_storage(storage, block_query, latest_block);
+        }
+    }
+}
+
+impl Default for SharedBlockHashCache {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(BlockHashRingBuffer::default())),
+        }
+    }
+}
+
+impl BlockHashLookup for SharedBlockHashCache {
     fn hash_by_number(&self, number: u64) -> Option<B256> {
-        let block = self
-            .block_query
-            .by_height(self.storage, number, false)
-            .ok()??;
-        Some(block.0.header.hash)
+        if let Ok(cache) = self.inner.read() {
+            cache.hash_by_number(number)
+        } else {
+            // TODO: deal with poisoning?
+            None
+        }
+    }
+}
+
+impl BlockHashWriter for SharedBlockHashCache {
+    fn push(&mut self, height: u64, hash: B256) {
+        if let Ok(mut cache) = self.inner.write() {
+            cache.push(height, hash)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ring_buffer_basic_operations() {
+        let mut buffer = BlockHashRingBuffer::default();
+        assert!(buffer.entries.is_empty());
+
+        let hash1 = B256::from([1u8; 32]);
+        let hash2 = B256::from([2u8; 32]);
+
+        buffer.push(1, hash1);
+        buffer.push(2, hash2);
+
+        assert_eq!(buffer.entries.len(), 2);
+        assert_eq!(buffer.hash_by_number(1), Some(hash1));
+        assert_eq!(buffer.hash_by_number(2), Some(hash2));
+        assert_eq!(buffer.latest_block, 2);
+    }
+
+    #[test]
+    fn test_ring_buffer_capacity() {
+        let mut buffer = BlockHashRingBuffer::default();
+
+        // Fill beyond capacity
+        for i in 0..300u64 {
+            let hash = B256::from([(i % 256) as u8; 32]);
+            buffer.push(i, hash);
+        }
+
+        assert_eq!(buffer.entries.len(), BLOCKHASH_HISTORY_SIZE);
+
+        // Should only have the most recent 256 blocks
+        assert_eq!(
+            buffer.entries.front(),
+            Some(BlockHashEntry {
+                number: 44,
+                hash: B256::from([44; 32])
+            })
+            .as_ref()
+        ); // 300 - 256 = 44
+        assert_eq!(buffer.latest_block, 299);
+    }
+
+    #[test]
+    fn test_out_of_range_blocks() {
+        let mut buffer = BlockHashRingBuffer::default();
+
+        // Add block 100
+        buffer.push(100, B256::from([1u8; 32]));
+        buffer.push(101, B256::from([2u8; 32]));
+
+        // Block too far in the past (more than 256 blocks ago) should return None
+        // Current block is 101, so block 101 - 256 = -155 would be too old
+        // But let's test with a more realistic scenario
+        for i in 102..400u64 {
+            buffer.push(i, B256::from([(i % 256) as u8; 32]));
+        }
+
+        // Now current block is 399
+        // Block 100 should be too old (399 - 100 = 299 > 256)
+        assert_eq!(buffer.hash_by_number(100), None);
+
+        // Block 143 should still be accessible (399 - 143 = 256, which is the limit)
+        assert_eq!(buffer.hash_by_number(143), None); // Actually should be None because 256 is > 256
+
+        // Block 144 should be accessible (399 - 144 = 255 < 256)
+        assert!(buffer.hash_by_number(144).is_some());
     }
 }

--- a/app/src/dependency.rs
+++ b/app/src/dependency.rs
@@ -11,6 +11,7 @@ pub struct ApplicationReader<D: Dependencies> {
     pub genesis_config: GenesisConfig,
     pub base_token: D::BaseTokenAccounts,
     pub block_queries: D::BlockQueries,
+    pub block_hash_lookup: D::BlockHashLookup,
     pub payload_queries: D::PayloadQueries,
     pub receipt_queries: D::ReceiptQueries,
     pub receipt_memory: D::ReceiptStorageReader,
@@ -28,6 +29,7 @@ impl<D: Dependencies> Clone for ApplicationReader<D> {
             genesis_config: self.genesis_config.clone(),
             base_token: self.base_token.clone(),
             block_queries: self.block_queries.clone(),
+            block_hash_lookup: self.block_hash_lookup.clone(),
             payload_queries: self.payload_queries.clone(),
             receipt_queries: self.receipt_queries.clone(),
             receipt_memory: self.receipt_memory.clone(),
@@ -44,6 +46,7 @@ impl<D: Dependencies> ApplicationReader<D> {
         Self {
             genesis_config: genesis_config.clone(),
             base_token: D::base_token_accounts(genesis_config),
+            block_hash_lookup: deps.block_hash_lookup(),
             block_queries: D::block_queries(),
             payload_queries: D::payload_queries(),
             receipt_queries: D::receipt_queries(),
@@ -59,6 +62,7 @@ impl<D: Dependencies> ApplicationReader<D> {
 pub struct Application<D: Dependencies> {
     pub genesis_config: GenesisConfig,
     pub mem_pool: Mempool,
+    pub block_hash_writer: D::BlockHashWriter,
     pub gas_fee: D::BaseGasFee,
     pub base_token: D::BaseTokenAccounts,
     pub l1_fee: D::CreateL1GasFee,
@@ -88,6 +92,7 @@ impl<D: Dependencies> Application<D> {
         Self {
             genesis_config: genesis_config.clone(),
             mem_pool: Mempool::default(),
+            block_hash_writer: deps.block_hash_writer(),
             gas_fee: D::base_gas_fee(),
             base_token: D::base_token_accounts(genesis_config),
             l1_fee: D::create_l1_gas_fee(),
@@ -122,6 +127,8 @@ pub trait DependenciesThreadSafe:
     Dependencies<
         BaseTokenAccounts: Send + 'static,
         BlockHash: Send + 'static,
+        BlockHashLookup: Send + 'static,
+        BlockHashWriter: Send + 'static,
         BlockQueries: Send + 'static,
         BlockRepository: Send + 'static,
         OnPayload: Send + Sync + 'static,
@@ -151,6 +158,8 @@ impl<
     T: Dependencies<
             BaseTokenAccounts: Send + 'static,
             BlockHash: Send + 'static,
+            BlockHashLookup: Send + 'static,
+            BlockHashWriter: Send + 'static,
             BlockQueries: Send + 'static,
             BlockRepository: Send + 'static,
             OnPayload: Send + Sync + 'static,
@@ -180,6 +189,8 @@ impl<
 pub trait Dependencies {
     type BaseTokenAccounts: umi_execution::BaseTokenAccounts + Clone;
     type BlockHash: umi_blockchain::block::BlockHash;
+    type BlockHashLookup: umi_evm_ext::state::BlockHashLookup + Clone;
+    type BlockHashWriter: umi_evm_ext::state::BlockHashWriter + Clone;
     type BlockQueries: umi_blockchain::block::BlockQueries<Storage = Self::SharedStorageReader>
         + Clone;
     type BlockRepository: umi_blockchain::block::BlockRepository<Storage = Self::SharedStorage>;
@@ -215,6 +226,10 @@ pub trait Dependencies {
     fn base_token_accounts(genesis_config: &GenesisConfig) -> Self::BaseTokenAccounts;
 
     fn block_hash() -> Self::BlockHash;
+
+    fn block_hash_lookup(&self) -> Self::BlockHashLookup;
+
+    fn block_hash_writer(&self) -> Self::BlockHashWriter;
 
     fn block_queries() -> Self::BlockQueries;
 
@@ -260,7 +275,7 @@ pub trait Dependencies {
 #[cfg(any(feature = "test-doubles", test))]
 mod test_doubles {
     use {
-        crate::{Application, Dependencies},
+        crate::{Application, Dependencies, SharedBlockHashCache},
         umi_blockchain::state::StateQueries,
         umi_genesis::config::GenesisConfig,
         umi_shared::primitives::U256,
@@ -272,6 +287,8 @@ mod test_doubles {
         S = umi_state::InMemoryState,
         BT = umi_execution::UmiBaseTokenAccounts,
         BH = umi_blockchain::block::UmiBlockHash,
+        BHL = SharedBlockHashCache,
+        BHW = SharedBlockHashCache,
         BQ = umi_blockchain::block::InMemoryBlockQueries,
         BR = umi_blockchain::block::InMemoryBlockRepository,
         PQ = umi_blockchain::payload::InMemoryPayloadQueries,
@@ -292,6 +309,8 @@ mod test_doubles {
         S,
         BT,
         BH,
+        BHL,
+        BHW,
         BQ,
         BR,
         PQ,
@@ -314,6 +333,8 @@ mod test_doubles {
         S: State + Send + 'static,
         BT: umi_execution::BaseTokenAccounts + Clone + Send + 'static,
         BH: umi_blockchain::block::BlockHash + Send + 'static,
+        BHL: umi_evm_ext::state::BlockHashLookup + Clone + Send + 'static,
+        BHW: umi_evm_ext::state::BlockHashWriter + Clone + Send + 'static,
         BQ: umi_blockchain::block::BlockQueries<Storage = BMR> + Clone + Send + 'static,
         BR: umi_blockchain::block::BlockRepository<Storage = B> + Send + 'static,
         PQ: umi_blockchain::payload::PayloadQueries<Storage = BMR> + Clone + Send + 'static,
@@ -335,6 +356,8 @@ mod test_doubles {
             S,
             BT,
             BH,
+            BHL,
+            BHW,
             BQ,
             BR,
             PQ,
@@ -354,6 +377,8 @@ mod test_doubles {
     {
         type BaseTokenAccounts = BT;
         type BlockHash = BH;
+        type BlockHashLookup = BHL;
+        type BlockHashWriter = BHW;
         type BlockQueries = BQ;
         type BlockRepository = BR;
         type OnPayload = crate::OnPayload<Application<Self>>;
@@ -380,6 +405,14 @@ mod test_doubles {
         }
 
         fn block_hash() -> Self::BlockHash {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn block_hash_lookup(&self) -> Self::BlockHashLookup {
+            unimplemented!("Dependencies are created manually in tests")
+        }
+
+        fn block_hash_writer(&self) -> Self::BlockHashWriter {
             unimplemented!("Dependencies are created manually in tests")
         }
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -13,4 +13,4 @@ mod queue;
 #[cfg(test)]
 mod tests;
 
-pub use {actor::*, dependency::*, factory::create, input::*, queue::CommandQueue};
+pub use {actor::*, block_hash::*, dependency::*, factory::create, input::*, queue::CommandQueue};

--- a/app/src/query.rs
+++ b/app/src/query.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{ApplicationReader, Dependencies, block_hash::StorageBasedProvider},
+    crate::{ApplicationReader, Dependencies},
     alloy::{
         consensus::Header,
         eips::{
@@ -81,7 +81,6 @@ impl<D: Dependencies> ApplicationReader<D> {
         block_number: BlockNumberOrTag,
         reward_percentiles: Option<Vec<f64>>,
     ) -> Result<FeeHistory> {
-        dbg!(self.block_number());
         if block_count < 1 {
             return Err(Error::User(UserError::InvalidBlockCount));
         }
@@ -153,15 +152,13 @@ impl<D: Dependencies> ApplicationReader<D> {
                                 percentiles
                                     .iter()
                                     .map(|p| {
-                                        dbg!(p);
                                         let threshold =
                                             ((block_gas_used as f64) * p / 100.0).round() as u64;
-                                        dbg!(&threshold);
                                         price_and_cum_gas
                                             .iter()
-                                            .find(|(_, cum_gas)| dbg!(cum_gas) >= &threshold)
-                                            .or_else(|| dbg!(price_and_cum_gas.last()))
-                                            .map(|(p, _)| dbg!(p))
+                                            .find(|(_, cum_gas)| cum_gas >= &threshold)
+                                            .or_else(|| price_and_cum_gas.last())
+                                            .map(|(p, _)| p)
                                             .copied()
                                             .unwrap_or(0u128)
                                     })
@@ -216,7 +213,6 @@ impl<D: Dependencies> ApplicationReader<D> {
                 .expect("Blocks should be non-empty"),
             Earliest => 0,
         };
-        let block_hash_lookup = StorageBasedProvider::new(&self.storage, &self.block_queries);
         let outcome = simulate_transaction(
             transaction,
             &self.state_queries.resolver_at(height),
@@ -224,7 +220,7 @@ impl<D: Dependencies> ApplicationReader<D> {
             &self.genesis_config,
             &self.base_token,
             block_height,
-            &block_hash_lookup,
+            &self.block_hash_lookup,
         );
 
         outcome.map(|outcome| {
@@ -239,14 +235,13 @@ impl<D: Dependencies> ApplicationReader<D> {
         block_number: BlockNumberOrTag,
     ) -> Result<Vec<u8>> {
         let height = self.resolve_height(block_number).unwrap();
-        let block_hash_lookup = StorageBasedProvider::new(&self.storage, &self.block_queries);
         call_transaction(
             transaction,
             &self.state_queries.resolver_at(height),
             &self.evm_storage,
             &self.genesis_config,
             &self.base_token,
-            &block_hash_lookup,
+            &self.block_hash_lookup,
         )
     }
 

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -29,7 +29,7 @@ use {
         state::{BlockHeight, InMemoryStateQueries, MockStateQueries, StateQueries},
         transaction::{InMemoryTransactionQueries, InMemoryTransactionRepository},
     },
-    umi_evm_ext::state::{InMemoryStorageTrieRepository, StorageTrieRepository},
+    umi_evm_ext::state::{BlockHashWriter, InMemoryStorageTrieRepository, StorageTrieRepository},
     umi_execution::{UmiBaseTokenAccounts, create_vm_session, session_id::SessionId},
     umi_genesis::{
         CreateMoveVm, UmiVm,
@@ -70,6 +70,7 @@ fn create_app_with_given_queries<SQ: StateQueries + Clone + Send + Sync + 'stati
     Application<TestDependencies<SQ>>,
 ) {
     let genesis_config = GenesisConfig::default();
+    let mut block_hash_cache = SharedBlockHashCache::default();
 
     let head_hash = B256::new(hex!(
         "e56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d"
@@ -84,6 +85,7 @@ fn create_app_with_given_queries<SQ: StateQueries + Clone + Send + Sync + 'stati
         block.block.header.number = i;
         block.hash = block.block.header.hash_slow();
         repository.add(&mut memory, block).unwrap();
+        block_hash_cache.push(i, head_hash);
     }
 
     let mut state = InMemoryState::default();
@@ -105,6 +107,7 @@ fn create_app_with_given_queries<SQ: StateQueries + Clone + Send + Sync + 'stati
             genesis_config: genesis_config.clone(),
             base_token: UmiBaseTokenAccounts::new(AccountAddress::ONE),
             block_queries: InMemoryBlockQueries,
+            block_hash_lookup: block_hash_cache.clone(),
             payload_queries: InMemoryPayloadQueries::new(),
             receipt_queries: InMemoryReceiptQueries::new(),
             receipt_memory: receipt_memory_reader.clone(),
@@ -117,6 +120,7 @@ fn create_app_with_given_queries<SQ: StateQueries + Clone + Send + Sync + 'stati
             mem_pool: Default::default(),
             genesis_config,
             base_token: UmiBaseTokenAccounts::new(AccountAddress::ONE),
+            block_hash_writer: block_hash_cache,
             block_hash: UmiBlockHash,
             block_queries: InMemoryBlockQueries,
             block_repository: repository,
@@ -186,6 +190,7 @@ fn create_app_with_fake_queries(
     Application<TestDependencies>,
 ) {
     let genesis_config = GenesisConfig::default();
+    let mut block_hash_cache = SharedBlockHashCache::default();
 
     let head_hash = B256::new(hex!(
         "e56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d"
@@ -195,11 +200,13 @@ fn create_app_with_fake_queries(
     let (memory_reader, mut memory) = shared_memory::new();
     let mut repository = InMemoryBlockRepository::new();
     repository.add(&mut memory, genesis_block.clone()).unwrap();
+    block_hash_cache.push(0, head_hash);
 
     for i in 1..=height {
         let mut block = genesis_block.clone();
         block.block.header.number = i;
         block.hash = block.block.header.hash_slow();
+        block_hash_cache.push(i, block.hash);
         repository.add(&mut memory, block).unwrap();
     }
 
@@ -227,6 +234,7 @@ fn create_app_with_fake_queries(
         ApplicationReader {
             genesis_config: genesis_config.clone(),
             base_token: UmiBaseTokenAccounts::new(AccountAddress::ONE),
+            block_hash_lookup: block_hash_cache.clone(),
             block_queries: InMemoryBlockQueries,
             payload_queries: InMemoryPayloadQueries::new(),
             receipt_queries: InMemoryReceiptQueries::new(),
@@ -241,6 +249,7 @@ fn create_app_with_fake_queries(
             genesis_config,
             base_token: UmiBaseTokenAccounts::new(AccountAddress::ONE),
             block_hash: UmiBlockHash,
+            block_hash_writer: block_hash_cache,
             block_queries: InMemoryBlockQueries,
             block_repository: repository,
             on_payload: CommandActor::on_payload_in_memory(),
@@ -726,7 +735,6 @@ fn test_fee_history_percentile_calculations(
 
     let result = reader.fee_history(1, Latest, Some(percentiles));
     assert!(result.is_ok());
-    dbg!(&result);
 
     let fee_history = result.unwrap();
     if let Some(rewards) = &fee_history.reward {
@@ -768,7 +776,6 @@ fn test_fee_history_gas_ratio_progression(tx_counts: Vec<usize>, expect_increasi
     assert!(result.is_ok());
 
     let fee_history = result.unwrap();
-    dbg!(&fee_history);
     assert_eq!(fee_history.gas_used_ratio.len(), tx_counts.len());
 
     if expect_increasing {

--- a/evm-ext/src/state/block_hash.rs
+++ b/evm-ext/src/state/block_hash.rs
@@ -6,6 +6,11 @@ pub trait BlockHashLookup {
     fn hash_by_number(&self, number: u64) -> Option<B256>;
 }
 
+/// A trait for keeping block hashes for 0x40 retrieval
+pub trait BlockHashWriter: BlockHashLookup {
+    fn push(&mut self, height: u64, hash: B256);
+}
+
 impl BlockHashLookup for () {
     fn hash_by_number(&self, _number: u64) -> Option<B256> {
         None

--- a/evm-ext/src/state/mod.rs
+++ b/evm-ext/src/state/mod.rs
@@ -2,4 +2,4 @@ mod account;
 mod block_hash;
 mod storage;
 
-pub use {account::*, block_hash::BlockHashLookup, storage::*};
+pub use {account::*, block_hash::*, storage::*};

--- a/server/src/dependency/heed.rs
+++ b/server/src/dependency/heed.rs
@@ -1,6 +1,6 @@
 use {
     crate::dependency::shared::*,
-    umi_app::{Application, ApplicationReader, CommandActor},
+    umi_app::{Application, ApplicationReader, CommandActor, SharedBlockHashCache},
     umi_blockchain::state::EthTrieStateQueries,
     umi_genesis::config::GenesisConfig,
     umi_state::{EthTrieState, State},
@@ -29,6 +29,8 @@ pub struct HeedDependencies;
 impl umi_app::Dependencies for HeedDependencies {
     type BlockQueries = block::HeedBlockQueries;
     type BlockRepository = block::HeedBlockRepository;
+    type BlockHashLookup = umi_app::SharedBlockHashCache;
+    type BlockHashWriter = umi_app::SharedBlockHashCache;
     type OnPayload = umi_app::OnPayload<Application<Self>>;
     type OnTx = umi_app::OnTx<Application<Self>>;
     type OnTxBatch = umi_app::OnTxBatch<Application<Self>>;
@@ -69,6 +71,14 @@ impl umi_app::Dependencies for HeedDependencies {
                 .push_state_root(state.state.state_root())
                 .unwrap()
         }
+    }
+
+    fn block_hash_lookup(&self) -> Self::BlockHashLookup {
+        BLOCK_HASH_CACHE.clone()
+    }
+
+    fn block_hash_writer(&self) -> Self::BlockHashWriter {
+        BLOCK_HASH_CACHE.clone()
     }
 
     fn payload_queries() -> Self::PayloadQueries {
@@ -132,6 +142,9 @@ lazy_static::lazy_static! {
     };
     static ref TRIE_DB: std::sync::Arc<trie::HeedEthTrieDb<'static>> = {
         std::sync::Arc::new(trie::HeedEthTrieDb::new(db()))
+    };
+    static ref BLOCK_HASH_CACHE: SharedBlockHashCache = {
+        SharedBlockHashCache::default()
     };
 }
 

--- a/server/src/dependency/in_memory.rs
+++ b/server/src/dependency/in_memory.rs
@@ -1,7 +1,7 @@
 use {
     crate::dependency::shared::*,
     std::sync::Arc,
-    umi_app::{Application, ApplicationReader, CommandActor},
+    umi_app::{Application, ApplicationReader, CommandActor, SharedBlockHashCache},
     umi_genesis::config::GenesisConfig,
 };
 
@@ -28,6 +28,7 @@ pub struct InMemoryDependencies {
     receipt_memory_reader: umi_blockchain::receipt::ReceiptMemoryReader,
     receipt_memory: Option<umi_blockchain::receipt::ReceiptMemory>,
     trie_db: Arc<umi_state::InMemoryTrieDb>,
+    block_hash_cache: SharedBlockHashCache,
 }
 
 impl InMemoryDependencies {
@@ -42,6 +43,7 @@ impl InMemoryDependencies {
             receipt_memory_reader,
             receipt_memory: Some(receipt_memory),
             trie_db: Arc::new(umi_state::InMemoryTrieDb::empty()),
+            block_hash_cache: SharedBlockHashCache::default(),
         }
     }
 
@@ -55,6 +57,7 @@ impl InMemoryDependencies {
             receipt_memory_reader: self.receipt_memory_reader.clone(),
             receipt_memory: None,
             trie_db: self.trie_db.clone(),
+            block_hash_cache: self.block_hash_cache.clone(),
         }
     }
 }
@@ -68,6 +71,8 @@ impl Default for InMemoryDependencies {
 impl umi_app::Dependencies for InMemoryDependencies {
     type BlockQueries = umi_blockchain::block::InMemoryBlockQueries;
     type BlockRepository = umi_blockchain::block::InMemoryBlockRepository;
+    type BlockHashLookup = umi_app::SharedBlockHashCache;
+    type BlockHashWriter = umi_app::SharedBlockHashCache;
     type OnPayload = umi_app::OnPayload<Application<Self>>;
     type OnTx = umi_app::OnTx<Application<Self>>;
     type OnTxBatch = umi_app::OnTxBatch<Application<Self>>;
@@ -114,6 +119,14 @@ impl umi_app::Dependencies for InMemoryDependencies {
 
     fn receipt_repository() -> Self::ReceiptRepository {
         umi_blockchain::receipt::InMemoryReceiptRepository::new()
+    }
+
+    fn block_hash_lookup(&self) -> Self::BlockHashLookup {
+        self.block_hash_cache.clone()
+    }
+
+    fn block_hash_writer(&self) -> Self::BlockHashWriter {
+        self.block_hash_cache.clone()
     }
 
     fn receipt_memory(&mut self) -> Self::ReceiptStorage {

--- a/server/src/dependency/rocksdb.rs
+++ b/server/src/dependency/rocksdb.rs
@@ -1,6 +1,6 @@
 use {
     crate::dependency::shared::*,
-    umi_app::{Application, ApplicationReader, CommandActor},
+    umi_app::{Application, ApplicationReader, CommandActor, SharedBlockHashCache},
     umi_blockchain::state::EthTrieStateQueries,
     umi_genesis::config::GenesisConfig,
     umi_state::{EthTrieState, State},
@@ -69,6 +69,14 @@ impl umi_app::Dependencies for RocksDbDependencies {
         }
     }
 
+    fn block_hash_lookup(&self) -> Self::BlockHashLookup {
+        BLOCK_HASH_CACHE.clone()
+    }
+
+    fn block_hash_writer(&self) -> Self::BlockHashWriter {
+        BLOCK_HASH_CACHE.clone()
+    }
+
     fn payload_queries() -> Self::PayloadQueries {
         umi_storage_rocksdb::payload::RocksDbPayloadQueries::new(db())
     }
@@ -132,6 +140,9 @@ lazy_static::lazy_static! {
         std::sync::Arc::new(
             umi_storage_rocksdb::RocksEthTrieDb::new(db()),
         )
+    };
+    static ref BLOCK_HASH_CACHE: SharedBlockHashCache = {
+        SharedBlockHashCache::default()
     };
 }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -177,6 +177,12 @@ pub fn initialize_app(
             &mut app.state,
             &mut app.evm_storage,
         );
+    } else {
+        app.block_hash_writer.initialize_from_storage(
+            &app.storage_reader,
+            &app.block_queries,
+            app_reader.block_number(),
+        );
     }
 
     (app, app_reader)

--- a/server/src/tests/evm_contracts.rs
+++ b/server/src/tests/evm_contracts.rs
@@ -20,6 +20,7 @@ mod evm_contract {
         // This contract has one function which uses the `BLOCKHASH` EVM opcode
         // to try to get the hash for block number 3. It emits the response
         // as an event.
+    #[derive(Debug)]
         contract BlockHash {
             event TheHash (
                 bytes32 indexed hash

--- a/server/src/tests/test_context.rs
+++ b/server/src/tests/test_context.rs
@@ -54,7 +54,7 @@ impl TestContext {
         self.timestamp += 1;
         let head_hash = self.head;
         let timestamp = self.timestamp;
-        let prev_rando = B256::random();
+        let prev_randao = B256::random();
         let request = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 7,
@@ -67,7 +67,7 @@ impl TestContext {
                 },
                 {
                     "timestamp": format!("{timestamp:#x}"),
-                    "prevRandao": format!("{prev_rando}"),
+                    "prevRandao": format!("{prev_randao}"),
                     "suggestedFeeRecipient": "0x4200000000000000000000000000000000000011",
                     "withdrawals": [],
                     "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
Replaces a db lookup for the BLOCKHASH opcode with a ring buffer implementation.
<!-- Fixes #123 -->
Fixes #352.

### Changes
<!-- Key changes -->
- Added the buffer into dependencies
- VecDeque-based implementation with a thread safe wrapper

### Testing
<!-- How was it tested? -->
Some new trivial tests, all old ones (with `evm_contracts.rs` being of special interest) pass too.

### Notes
<!-- Additional info -->