### PR TITLE
refactor(state): Unify `apply` and `apply_with_tables`

### DIFF
--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -91,10 +91,9 @@ mod tests {
         let trie_db = Arc::new(InMemoryTrieDb::empty());
         let mut state = InMemoryState::empty(trie_db.clone());
         let mut evm_storage = InMemoryStorageTrieRepository::new();
-        let (changes, table_changes, evm_storage_changes) = umi_genesis_image::load();
+        let (changes, evm_storage_changes) = umi_genesis_image::load();
         umi_genesis::apply(
             changes.clone(),
-            table_changes,
             evm_storage_changes,
             &genesis_config,
             &mut state,

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -85,10 +85,9 @@ pub mod tests {
             genesis_config.initial_state_root,
         );
         let mut evm_storage = InMemoryStorageTrieRepository::new();
-        let (changes, table_changes, evm_storage_changes) = umi_genesis_image::load();
+        let (changes, evm_storage_changes) = umi_genesis_image::load();
         umi_genesis::apply(
             changes.clone(),
-            table_changes,
             evm_storage_changes,
             &genesis_config,
             &mut state,

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -270,10 +270,9 @@ mod tests {
         let trie_db = Arc::new(InMemoryTrieDb::empty());
         let mut state = InMemoryState::empty(trie_db.clone());
         let mut evm_storage = InMemoryStorageTrieRepository::new();
-        let (changes, table_changes, evm_storage_changes) = umi_genesis_image::load();
+        let (changes, evm_storage_changes) = umi_genesis_image::load();
         umi_genesis::apply(
             changes.clone(),
-            table_changes,
             evm_storage_changes,
             &genesis_config,
             &mut state,

--- a/app/src/command.rs
+++ b/app/src/command.rs
@@ -243,7 +243,7 @@ impl<D: Dependencies> Application<D> {
                 .as_ref()
                 .and_then(|x| x.l1_block_info(pending_tx.l1_gas_fee_input.clone()));
 
-            self.on_tx(outcome.changes.move_vm.clone());
+            self.on_tx(outcome.changes.move_vm.clone().accounts);
 
             self.state
                 .apply(outcome.changes.move_vm)

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -88,10 +88,9 @@ fn create_app_with_given_queries<SQ: StateQueries + Clone + Send + Sync + 'stati
 
     let mut state = InMemoryState::default();
     let mut evm_storage = InMemoryStorageTrieRepository::new();
-    let (changes, tables, evm_storage_changes) = umi_genesis_image::load();
+    let (changes, evm_storage_changes) = umi_genesis_image::load();
     umi_genesis::apply(
         changes,
-        tables,
         evm_storage_changes,
         &genesis_config,
         &mut state,
@@ -206,14 +205,12 @@ fn create_app_with_fake_queries(
     let evm_storage = InMemoryStorageTrieRepository::new();
     let trie_db = Arc::new(InMemoryTrieDb::empty());
     let mut state = InMemoryState::empty(trie_db.clone());
-    let (genesis_changes, table_changes, evm_storage_changes) = umi_genesis_image::load();
+    let (genesis_changes, evm_storage_changes) = umi_genesis_image::load();
 
-    state
-        .apply_with_tables(genesis_changes.clone(), table_changes)
-        .unwrap();
+    state.apply(genesis_changes).unwrap();
     evm_storage.apply(evm_storage_changes).unwrap();
     let changes_addition = mint_eth(&state, &evm_storage, addr, initial_balance);
-    state.apply(changes_addition.clone()).unwrap();
+    state.apply(changes_addition.clone().into()).unwrap();
 
     let (receipt_reader, receipt_memory) = receipt_memory::new();
 

--- a/execution/src/canonical.rs
+++ b/execution/src/canonical.rs
@@ -307,7 +307,7 @@ pub(super) fn execute_canonical_transaction<
     changes
         .squash(deploy_changes)
         .expect("Module deploy changes must merge with other session changes");
-    let changes = Changes::new(changes, evm_changes.storage);
+    let changes = Changes::new(changes.into(), evm_changes.storage);
 
     match vm_outcome {
         Ok(_) => Ok(TransactionExecutionOutcome::new(

--- a/execution/src/deposited.rs
+++ b/execution/src/deposited.rs
@@ -146,7 +146,7 @@ pub(super) fn execute_deposited_transaction<
     changes
         .squash(evm_changes.accounts)
         .expect("EVM changes must merge with other session changes");
-    let changes = Changes::new(changes, evm_changes.storage);
+    let changes = Changes::new(changes.into(), evm_changes.storage);
 
     Ok(TransactionExecutionOutcome::new(
         vm_outcome,

--- a/execution/src/tests/utils.rs
+++ b/execution/src/tests/utils.rs
@@ -109,10 +109,9 @@ impl TestContext {
         let genesis_config = GenesisConfig::default();
         let mut state = InMemoryState::default();
         let mut evm_storage = InMemoryStorageTrieRepository::new();
-        let (changes, tables, evm_storage_changes) = umi_genesis_image::load();
+        let (changes, evm_storage_changes) = umi_genesis_image::load();
         umi_genesis::apply(
             changes,
-            tables,
             evm_storage_changes,
             &genesis_config,
             &mut state,
@@ -553,7 +552,7 @@ impl TestContext {
         changes.squash(evm_changes.accounts).unwrap();
         drop(extensions);
 
-        self.state.apply(changes).unwrap();
+        self.state.apply(changes.into()).unwrap();
         self.evm_storage.apply(evm_changes.storage).unwrap();
         outcome
     }

--- a/execution/src/transaction.rs
+++ b/execution/src/transaction.rs
@@ -9,9 +9,7 @@ use {
         rpc::types::TransactionRequest,
     },
     aptos_types::transaction::{EntryFunction, Module, Script},
-    move_core_types::{
-        account_address::AccountAddress, effects::ChangeSet, language_storage::ModuleId,
-    },
+    move_core_types::{account_address::AccountAddress, language_storage::ModuleId},
     op_alloy::consensus::{
         OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope, OpTxEnvelope, TxDeposit,
     },
@@ -113,7 +111,7 @@ impl NormalizedExtendedTxEnvelope {
     }
 }
 
-type MoveChanges = ChangeSet;
+type MoveChanges = umi_state::Changes;
 type EvmChanges = umi_evm_ext::state::StorageTriesChanges;
 
 #[derive(Debug, Clone)]

--- a/genesis-image/build.rs
+++ b/genesis-image/build.rs
@@ -25,10 +25,10 @@ pub fn save(
     storage_trie: &impl StorageTrieRepository,
 ) -> (ChangeSet, TableChangeSet) {
     let path = std::env::var("OUT_DIR").unwrap() + "/genesis.bin";
-    let (changes, table_changes, evm_storage) = build(vm, config, storage_trie);
-    let changes = SerdeChanges::from(changes);
-    let tables = SerdeTableChangeSet::from(table_changes);
-    let all_changes = SerdeAllChanges::new(changes, tables, evm_storage.into());
+    let (changes, evm_storage) = build(vm, config, storage_trie);
+    let accounts = SerdeChanges::from(changes.accounts);
+    let tables = SerdeTableChangeSet::from(changes.tables);
+    let all_changes = SerdeAllChanges::new(accounts, tables, evm_storage.into());
     let contents = bcs::to_bytes(&all_changes).unwrap();
     let mut file = std::fs::File::create(path).unwrap();
     file.write_all(contents.as_slice()).unwrap();

--- a/genesis-image/src/lib.rs
+++ b/genesis-image/src/lib.rs
@@ -1,15 +1,11 @@
-use {
-    move_core_types::effects::ChangeSet, move_table_extension::TableChangeSet,
-    umi_evm_ext::state::StorageTriesChanges, umi_genesis::SerdeAllChanges,
-};
+use {umi_evm_ext::state::StorageTriesChanges, umi_genesis::SerdeAllChanges, umi_state::Changes};
 
-pub fn load() -> (ChangeSet, TableChangeSet, StorageTriesChanges) {
+pub fn load() -> (Changes, StorageTriesChanges) {
     let contents = include_bytes!(concat!(env!("OUT_DIR"), "/genesis.bin"));
     let contents: SerdeAllChanges = bcs::from_bytes(contents).expect("File should be bcs encoded");
 
     (
-        contents.changes.into(),
-        contents.tables.into(),
+        Changes::new(contents.changes.into(), contents.tables.into()),
         contents.evm_storage.into(),
     )
 }

--- a/genesis/src/framework.rs
+++ b/genesis/src/framework.rs
@@ -219,7 +219,7 @@ fn deploy_aptos_framework(state: &mut impl State, umi_vm: &UmiVm) -> Result<Chan
         };
         // We need to add changes on a package-by-package basis so that other packages in the framework
         // can link against previous ones, but also pass it outside for genesis image generation
-        state.apply(package_writes.clone()).unwrap();
+        state.apply(package_writes.clone().into()).unwrap();
         framework_writes
             .squash(package_writes)
             .expect("Packages in framework should not conflict with each other");
@@ -278,7 +278,7 @@ fn deploy_sui_framework(state: &mut impl State, umi_vm: &UmiVm) -> Result<Change
     )?;
     let bundle = staged_stdlib_storage.release_verified_module_bundle();
     let stdlib_writes = convert_bundle_into_module_ops(bundle)?;
-    state.apply(stdlib_writes.clone()).unwrap();
+    state.apply(stdlib_writes.clone().into()).unwrap();
     total_writes
         .squash(stdlib_writes)
         .expect("Sui stdlib can be squashed with empty change set");
@@ -301,7 +301,7 @@ fn deploy_sui_framework(state: &mut impl State, umi_vm: &UmiVm) -> Result<Change
     )?;
     let bundle = staged_framework_storage.release_verified_module_bundle();
     let framework_writes = convert_bundle_into_module_ops(bundle)?;
-    state.apply(framework_writes.clone()).unwrap();
+    state.apply(framework_writes.clone().into()).unwrap();
     total_writes
         .squash(framework_writes)
         .expect("Sui framework can be squashed with stdlib");

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -155,7 +155,7 @@ pub fn initialize_app(
         .unwrap()
         .is_none()
     {
-        let (genesis_changes, table_changes, evm_storage_changes) = {
+        let (genesis_changes, evm_storage_changes) = {
             #[cfg(test)]
             {
                 umi_genesis_image::load()
@@ -171,7 +171,6 @@ pub fn initialize_app(
         };
         umi_genesis::apply(
             genesis_changes,
-            table_changes,
             evm_storage_changes,
             &genesis_config,
             &mut app.state,

--- a/state/src/diff.rs
+++ b/state/src/diff.rs
@@ -1,0 +1,126 @@
+use {
+    core::fmt,
+    move_core_types::effects::ChangeSet,
+    move_table_extension::{TableChange, TableChangeSet},
+    std::fmt::{Debug, DebugStruct, Formatter},
+};
+
+/// Represents the difference between two [`State`]s.
+///
+/// The difference can be [applied]. If the difference is between two states `S` and `S'`, then it
+/// must be true that `S' := apply(S, Changes)`.
+///
+/// `Changes` are usually produced by running a transaction on state `S`, in which case `S'`
+/// represents the state after.
+///
+/// [`State`]: crate::State
+/// [applied]: crate::State::apply
+pub struct Changes {
+    pub accounts: ChangeSet,
+    pub tables: TableChangeSet,
+}
+
+impl Changes {
+    pub fn empty() -> Self {
+        Self {
+            accounts: ChangeSet::new(),
+            tables: TableChangeSet::default(),
+        }
+    }
+
+    pub fn new(accounts: ChangeSet, tables: TableChangeSet) -> Self {
+        Self { accounts, tables }
+    }
+}
+
+impl Debug for Changes {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        /// A `Closure` wrapper.
+        ///
+        /// Implements [`Debug`] if the `Closure` has the same signature as [`Debug::fmt`].
+        struct DebugClosure<Closure>(Closure);
+
+        impl<F: Fn(&mut Formatter<'_>) -> fmt::Result> Debug for DebugClosure<F> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                self.0(f)
+            }
+        }
+
+        /// An extension trait that provides the closure based debug formatting.
+        trait FieldWithStable {
+            /// Adds a new field to the generated struct output.
+            ///
+            /// This method is equivalent to [`DebugStruct::field`], but formats the
+            /// value using a provided closure rather than by calling [`Debug::fmt`].
+            fn field_with_stable<F>(&mut self, name: &str, value_fmt: F) -> &mut Self
+            where
+                F: Fn(&mut Formatter<'_>) -> fmt::Result;
+        }
+
+        impl FieldWithStable for DebugStruct<'_, '_> {
+            fn field_with_stable<F>(&mut self, name: &str, value_fmt: F) -> &mut Self
+            where
+                F: Fn(&mut Formatter<'_>) -> std::fmt::Result,
+            {
+                self.field(name, &DebugClosure(value_fmt))
+            }
+        }
+
+        f.debug_struct("Changes")
+            .field("accounts", &self.accounts)
+            .field_with_stable("tables", |f| {
+                f.debug_struct("TableChangeSet")
+                    .field_with_stable("changes", |f| {
+                        f.debug_map()
+                            .entries(self.tables.changes.iter().map(|(k, v)| (k, &v.entries)))
+                            .finish()
+                    })
+                    .field_with_stable("new_tables", |f| {
+                        f.debug_map()
+                            .entries(self.tables.new_tables.iter())
+                            .finish()
+                    })
+                    .field_with_stable("removed_tables", |f| {
+                        f.debug_set()
+                            .entries(self.tables.removed_tables.iter())
+                            .finish()
+                    })
+                    .finish()
+            })
+            .finish()
+    }
+}
+
+impl Clone for Changes {
+    fn clone(&self) -> Self {
+        Self {
+            accounts: self.accounts.clone(),
+            tables: TableChangeSet {
+                new_tables: self.tables.new_tables.clone(),
+                removed_tables: self.tables.removed_tables.clone(),
+                changes: self
+                    .tables
+                    .changes
+                    .iter()
+                    .map(|(k, v)| {
+                        (
+                            *k,
+                            TableChange {
+                                entries: v.entries.clone(),
+                            },
+                        )
+                    })
+                    .collect(),
+            },
+        }
+    }
+}
+
+impl From<ChangeSet> for Changes {
+    fn from(accounts: ChangeSet) -> Self {
+        Self {
+            accounts,
+            tables: Default::default(),
+        }
+    }
+}

--- a/state/src/state.rs
+++ b/state/src/state.rs
@@ -1,8 +1,7 @@
 use {
-    crate::{EthTrieResolver, InsertChangeSetIntoMerkleTrie, State},
+    crate::{Changes, EthTrieResolver, InsertChangeSetIntoMerkleTrie, State},
     eth_trie::{DB, EthTrie, TrieError},
-    move_core_types::effects::ChangeSet,
-    move_table_extension::{TableChangeSet, TableResolver},
+    move_table_extension::TableResolver,
     move_vm_types::resolver::MoveResolver,
     std::sync::Arc,
     umi_evm_ext::state::DbWithRoot,
@@ -47,22 +46,14 @@ impl<D: DbWithRoot> EthTrieState<D> {
 impl<D: DbWithRoot> State for EthTrieState<D> {
     type Err = TrieError;
 
-    fn apply(&mut self, changes: ChangeSet) -> Result<(), Self::Err> {
+    fn apply(&mut self, changes: Changes) -> Result<(), Self::Err> {
         let root = self
             .trie_mut()
-            .insert_change_set_into_merkle_trie(&changes)?;
+            .insert_change_set_into_merkle_trie(&changes.accounts)?;
         self.state_root.replace(root);
         self.db()
             .put_root(root)
             .map_err(|e| TrieError::DB(e.to_string()))
-    }
-
-    fn apply_with_tables(
-        &mut self,
-        changes: ChangeSet,
-        _table_changes: TableChangeSet,
-    ) -> Result<(), Self::Err> {
-        self.apply(changes)
     }
 
     fn db(&self) -> Arc<impl DB> {


### PR DESCRIPTION
### Description
Removes `apply_with_tables` and adds table changes to `apply`.

### Changes
<!-- Key changes -->
- Remove `State::apply_with_tables`
- Add `Changes` for representing a difference between states
- Include `TableChanges` in `Changes`

### Testing
:green_circle: fmt
:green_circle: clippy
:green_circle: test