### PR TITLE
ci(flaky): Free up disk space before compilation

### DIFF
--- a/.github/workflows/build_and_run_tests.yaml
+++ b/.github/workflows/build_and_run_tests.yaml
@@ -33,6 +33,8 @@ jobs:
         with:
           default: true
           toolchain: stable
+      - name: Free up disk space
+        run: rm -rf /opt/hostedtoolcache
       - name: Run flaky tests
         run: cargo test -- --ignored
         continue-on-error: true


### PR DESCRIPTION
### Description
The job currently always fail due to "not enough space on device" error.

Fixes the problem in the same way as for the regular test job.

### Changes
- Add "free up disk space" step to flaky job before compilation

### Testing
:green_circle: Github actions