### PR TITLE
ci(build): Merge tests and flaky tests

### DIFF
--- a/.github/workflows/build_and_run_tests.yaml
+++ b/.github/workflows/build_and_run_tests.yaml
@@ -23,18 +23,6 @@ jobs:
         run: rm -rf /opt/hostedtoolcache
       - name: Test
         run: cargo test -- --skip integration
-
-  flaky:
-    name: flaky
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          default: true
-          toolchain: stable
-      - name: Free up disk space
-        run: rm -rf /opt/hostedtoolcache
       - name: Run flaky tests
         run: cargo test -- --ignored
         continue-on-error: true


### PR DESCRIPTION
### Description
The flaky tests can be run as a fallible step instead of their own job. That will save about 20 minutes worth of extra compilation.

### Changes
<!-- Key changes -->
- Remove `flaky` job
- Add fallible step to run ignored tests in the main `build_and_run_tests` job

### Testing
:green_circle: Github actions