### PR TITLE
Feat(gas): Charge gas for storage usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12474,8 +12474,10 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "bcs 0.1.3",
+ "bytes",
  "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.27.2)",
  "move-core-types 0.0.4 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.27.2)",
+ "move-vm-types 0.1.0 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.27.2)",
  "op-alloy",
  "test-case",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12366,6 +12366,7 @@ dependencies = [
  "aptos-types",
  "aptos-vm",
  "bcs 0.1.3",
+ "bytes",
  "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.27.2)",
  "move-compiler 0.0.1 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.27.2)",
  "move-compiler-v2",

--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -131,6 +131,7 @@ mod tests {
             on_tx: CommandActor::on_tx_noop(),
             on_tx_batch: CommandActor::on_tx_batch_noop(),
             on_payload: CommandActor::on_payload_in_memory(),
+            resolver_cache: Default::default(),
         };
         let reader = ApplicationReader::<
             TestDependencies<

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -133,6 +133,7 @@ pub mod tests {
                 evm_storage,
                 transaction_queries: InMemoryTransactionQueries::new(),
                 transaction_repository: InMemoryTransactionRepository::new(),
+                resolver_cache: Default::default(),
             },
         )
     }
@@ -297,6 +298,7 @@ pub mod tests {
                 evm_storage: (),
                 transaction_queries: (),
                 transaction_repository: (),
+                resolver_cache: Default::default(),
             },
         ))
     }

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -312,6 +312,7 @@ mod tests {
                 genesis_state_root,
             ),
             transaction_repository: InMemoryTransactionRepository::new(),
+            resolver_cache: Default::default(),
         };
         let reader = ApplicationReader::<
             TestDependencies<

--- a/app/src/command.rs
+++ b/app/src/command.rs
@@ -232,7 +232,7 @@ impl<D: Dependencies> Application<D> {
                 }
                 .into(),
             };
-            let outcome = match execute_transaction(input) {
+            let outcome = match execute_transaction(input, &mut self.resolver_cache) {
                 Ok(outcome) => outcome,
                 Err(User(e)) => unreachable!("User errors are handled in execution {e:?}"),
                 Err(InvalidTransaction(_)) => continue,

--- a/app/src/dependency.rs
+++ b/app/src/dependency.rs
@@ -1,6 +1,7 @@
 use crate::mempool::Mempool;
 #[cfg(any(feature = "test-doubles", test))]
 pub use test_doubles::TestDependencies;
+use umi_execution::resolver_cache::ResolverCache;
 
 use {
     move_core_types::effects::ChangeSet, umi_blockchain::payload::PayloadId,
@@ -81,6 +82,10 @@ pub struct Application<D: Dependencies> {
     pub evm_storage: D::StorageTrieRepository,
     pub transaction_queries: D::TransactionQueries,
     pub transaction_repository: D::TransactionRepository,
+    // Note: the purpose of having the resolver cache here is to reuse the memory
+    // allocated for the cache for all transaction execution instead of continuously
+    // allocating and releasing memory.
+    pub resolver_cache: ResolverCache,
 }
 
 impl<D: Dependencies> Application<D> {
@@ -110,6 +115,7 @@ impl<D: Dependencies> Application<D> {
             evm_storage: D::storage_trie_repository(),
             transaction_queries: D::transaction_queries(),
             transaction_repository: D::transaction_repository(),
+            resolver_cache: ResolverCache::default(),
         }
     }
 

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -137,6 +137,7 @@ fn create_app_with_given_queries<SQ: StateQueries + Clone + Send + Sync + 'stati
             gas_fee: Eip1559GasFee::default(),
             l1_fee: U256::ZERO,
             l2_fee: U256::ZERO,
+            resolver_cache: Default::default(),
         },
     )
 }
@@ -258,6 +259,7 @@ fn create_app_with_fake_queries(
             gas_fee: Eip1559GasFee::default(),
             l1_fee: U256::ZERO,
             l2_fee: U256::ZERO,
+            resolver_cache: Default::default(),
         },
     )
 }

--- a/execution/Cargo.toml
+++ b/execution/Cargo.toml
@@ -19,6 +19,7 @@ aptos-table-natives.workspace = true
 aptos-types.workspace = true
 aptos-vm.workspace = true
 bcs.workspace = true
+bytes.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
 move-table-extension.workspace = true

--- a/execution/src/deposited.rs
+++ b/execution/src/deposited.rs
@@ -6,6 +6,7 @@ use {
         transaction::{Changes, TransactionExecutionOutcome},
     },
     alloy::primitives::U256,
+    aptos_framework::natives::event::NativeEventContext,
     aptos_table_natives::TableResolver,
     move_core_types::language_storage::ModuleId,
     move_vm_runtime::{
@@ -139,7 +140,8 @@ pub(super) fn execute_deposited_transaction<
     };
 
     let (mut changes, mut extensions) = session.finish_with_extensions(&code_storage)?;
-    let mut logs = extensions.logs();
+    let events = extensions.remove::<NativeEventContext>().into_events();
+    let mut logs = events.logs();
     logs.extend(evm_logs);
     let gas_used = total_gas_used(&gas_meter, input.genesis_config);
     let evm_changes = extract_evm_changes(&extensions);

--- a/execution/src/lib.rs
+++ b/execution/src/lib.rs
@@ -9,6 +9,7 @@ pub use {
 };
 
 use {
+    crate::resolver_cache::ResolverCache,
     alloy::primitives::{Bloom, Keccak256, Log, LogData},
     aptos_framework::natives::{
         event::NativeEventContext, object::NativeObjectContext,
@@ -41,6 +42,7 @@ use {
     umi_shared::primitives::{B256, ToEthAddress},
 };
 
+pub mod resolver_cache;
 pub mod session_id;
 pub mod simulate;
 pub mod transaction;
@@ -164,10 +166,13 @@ pub fn execute_transaction<
     H: BlockHashLookup,
 >(
     input: TransactionExecutionInput<S, ST, F, B, H>,
+    resolver_cache: &mut ResolverCache,
 ) -> umi_shared::error::Result<TransactionExecutionOutcome> {
     match input {
         TransactionExecutionInput::Deposit(input) => execute_deposited_transaction(input),
-        TransactionExecutionInput::Canonical(input) => execute_canonical_transaction(input),
+        TransactionExecutionInput::Canonical(input) => {
+            execute_canonical_transaction(input, resolver_cache)
+        }
     }
 }
 

--- a/execution/src/lib.rs
+++ b/execution/src/lib.rs
@@ -185,14 +185,16 @@ impl<'a, I: Iterator<Item = &'a Log>> LogsBloom for I {
 }
 
 trait Logs {
-    fn logs(&mut self) -> Vec<Log>;
+    fn logs(self) -> Vec<Log>;
 }
 
-impl Logs for NativeContextExtensions<'_> {
-    fn logs(&mut self) -> Vec<Log> {
+impl<T> Logs for T
+where
+    T: IntoIterator<Item = (ContractEvent, Option<MoveTypeLayout>)>,
+{
+    fn logs(self) -> Vec<Log> {
         let mut result = Vec::new();
-        let events = self.remove::<NativeEventContext>().into_events();
-        for (event, _) in events {
+        for (event, _) in self.into_iter() {
             push_logs(&event, &mut result);
         }
         result

--- a/execution/src/resolver_cache.rs
+++ b/execution/src/resolver_cache.rs
@@ -1,0 +1,142 @@
+use {
+    aptos_table_natives::{TableHandle, TableResolver},
+    bytes::Bytes,
+    move_binary_format::errors::PartialVMResult,
+    move_core_types::{
+        account_address::AccountAddress,
+        language_storage::{ModuleId, StructTag},
+        metadata::Metadata,
+        value::MoveTypeLayout,
+    },
+    move_vm_types::resolver::{ModuleResolver, MoveResolver, ResourceResolver},
+    std::{
+        cell::RefCell,
+        collections::{HashMap, hash_map::Entry},
+        hash::Hash,
+        ops::Deref,
+    },
+};
+
+#[derive(Debug, Default)]
+pub struct ResolverCache {
+    resource_cache: HashMap<(AccountAddress, StructTag), Option<Bytes>>,
+    modules_cache: HashMap<ModuleId, Option<Bytes>>,
+}
+
+impl ResolverCache {
+    pub fn resource_original_size(
+        &self,
+        address: &AccountAddress,
+        struct_tag: &StructTag,
+    ) -> usize {
+        let cache_key = (*address, struct_tag.clone());
+        bytes_len(&cache_key, &self.resource_cache)
+    }
+
+    pub fn module_original_size(&self, id: &ModuleId) -> usize {
+        bytes_len(id, &self.modules_cache)
+    }
+
+    pub fn clear(&mut self) {
+        self.resource_cache.clear();
+        self.modules_cache.clear();
+    }
+}
+
+pub struct CachedResolver<'a, 'b, R> {
+    inner: &'a R,
+    cache: RefCell<&'b mut ResolverCache>,
+}
+
+impl<'a, 'b, R> CachedResolver<'a, 'b, R>
+where
+    R: MoveResolver + TableResolver,
+{
+    pub fn new(resolver: &'a R, cache: &'b mut ResolverCache) -> Self {
+        Self {
+            inner: resolver,
+            cache: RefCell::new(cache),
+        }
+    }
+}
+
+impl<'b, R> CachedResolver<'_, 'b, R> {
+    pub fn borrow_cache<'a>(&'a self) -> impl Deref<Target = &'b mut ResolverCache> + 'a {
+        self.cache.borrow()
+    }
+}
+
+impl<R> ResourceResolver for CachedResolver<'_, '_, R>
+where
+    R: ResourceResolver,
+{
+    fn get_resource_bytes_with_metadata_and_layout(
+        &self,
+        address: &AccountAddress,
+        struct_tag: &StructTag,
+        metadata: &[Metadata],
+        layout: Option<&MoveTypeLayout>,
+    ) -> PartialVMResult<(Option<Bytes>, usize)> {
+        let cache_key = (*address, struct_tag.clone());
+        match self.cache.borrow_mut().resource_cache.entry(cache_key) {
+            Entry::Occupied(entry) => {
+                let cache_hit = entry.get();
+                let size = cache_hit.as_ref().map(Bytes::len).unwrap_or(0);
+                Ok((cache_hit.clone(), size))
+            }
+            Entry::Vacant(entry) => {
+                let (bytes, size) = self.inner.get_resource_bytes_with_metadata_and_layout(
+                    address, struct_tag, metadata, layout,
+                )?;
+                let bytes = entry.insert(bytes);
+                Ok((bytes.clone(), size))
+            }
+        }
+    }
+}
+
+impl<R> ModuleResolver for CachedResolver<'_, '_, R>
+where
+    R: ModuleResolver,
+{
+    fn get_module(&self, id: &ModuleId) -> PartialVMResult<Option<Bytes>> {
+        let cache_key = id.clone();
+        match self.cache.borrow_mut().modules_cache.entry(cache_key) {
+            Entry::Occupied(entry) => {
+                let cache_hit = entry.get();
+                Ok(cache_hit.clone())
+            }
+            Entry::Vacant(entry) => {
+                let bytes = self.inner.get_module(id)?;
+                let bytes = entry.insert(bytes);
+                Ok(bytes.clone())
+            }
+        }
+    }
+
+    fn get_module_metadata(&self, module_id: &ModuleId) -> Vec<Metadata> {
+        self.inner.get_module_metadata(module_id)
+    }
+}
+
+impl<R> TableResolver for CachedResolver<'_, '_, R>
+where
+    R: TableResolver,
+{
+    fn resolve_table_entry_bytes_with_layout(
+        &self,
+        handle: &TableHandle,
+        key: &[u8],
+        maybe_layout: Option<&MoveTypeLayout>,
+    ) -> PartialVMResult<Option<Bytes>> {
+        self.inner
+            .resolve_table_entry_bytes_with_layout(handle, key, maybe_layout)
+    }
+}
+
+fn bytes_len<K: Eq + Hash>(key: &K, cache: &HashMap<K, Option<Bytes>>) -> usize {
+    cache
+        .get(key)
+        .map(|bytes| bytes.as_ref().map(Bytes::len).unwrap_or(0))
+        .unwrap_or(0)
+}

--- a/execution/src/simulate.rs
+++ b/execution/src/simulate.rs
@@ -8,6 +8,7 @@ use {
         execute_transaction,
         gas::new_gas_meter,
         quick_get_nonce,
+        resolver_cache::ResolverCache,
         session_id::SessionId,
         transaction::{
             NormalizedEthTransaction, ScriptOrDeployment, TransactionData,
@@ -73,7 +74,7 @@ pub fn simulate_transaction(
         block_hash_lookup,
     };
 
-    execute_transaction(input.into())
+    execute_transaction(input.into(), &mut ResolverCache::default())
 }
 
 pub fn call_transaction(

--- a/execution/src/simulate.rs
+++ b/execution/src/simulate.rs
@@ -101,7 +101,7 @@ pub fn call_transaction(
     let mut traversal_context = TraversalContext::new(&traversal_storage);
     let mut gas_meter = new_gas_meter(genesis_config, tx.gas_limit());
 
-    let mut verify_input = CanonicalVerificationInput {
+    verify_transaction(CanonicalVerificationInput {
         tx: &tx,
         session: &mut session,
         traversal_context: &mut traversal_context,
@@ -111,18 +111,17 @@ pub fn call_transaction(
         l2_cost: U256::ZERO,
         base_token,
         module_storage: &code_storage,
-    };
-    verify_transaction(&mut verify_input)?;
+    })?;
 
     match tx_data {
         TransactionData::EntryFunction(entry_fn) => {
-            let outcome = verify_input.session.execute_function_bypass_visibility(
+            let outcome = session.execute_function_bypass_visibility(
                 entry_fn.module(),
                 entry_fn.function(),
                 entry_fn.ty_args().to_vec(),
                 entry_fn.args().to_vec(),
-                verify_input.gas_meter,
-                verify_input.traversal_context,
+                &mut gas_meter,
+                &mut traversal_context,
                 &code_storage,
             )?;
             // Only return the results of the transaction in bytes without the Move value layout.
@@ -139,9 +138,9 @@ pub fn call_transaction(
             crate::execute::execute_script(
                 script,
                 &tx.signer.to_move_address(),
-                verify_input.session,
-                verify_input.traversal_context,
-                verify_input.gas_meter,
+                &mut session,
+                &mut traversal_context,
+                &mut gas_meter,
                 &code_storage,
             )?;
             Ok(vec![])
@@ -152,9 +151,9 @@ pub fn call_transaction(
                 &contract.to_move_address(),
                 tx.value,
                 tx.data.to_vec(),
-                verify_input.session,
-                verify_input.traversal_context,
-                verify_input.gas_meter,
+                &mut session,
+                &mut traversal_context,
+                &mut gas_meter,
                 &code_storage,
             )?;
             Ok(outcome.output)
@@ -165,9 +164,9 @@ pub fn call_transaction(
                 &address.to_move_address(),
                 tx.value,
                 data,
-                verify_input.session,
-                verify_input.traversal_context,
-                verify_input.gas_meter,
+                &mut session,
+                &mut traversal_context,
+                &mut gas_meter,
                 &code_storage,
             )?;
             Ok(outcome.output)

--- a/execution/src/tests/evm_native.rs
+++ b/execution/src/tests/evm_native.rs
@@ -159,7 +159,7 @@ fn test_solidity_fixed_bytes() {
                 block_header: HeaderForExecution::default(),
                 block_hash_lookup: &(),
             };
-            execute_transaction(input.into()).unwrap()
+            execute_transaction(input.into(), &mut Default::default()).unwrap()
         };
 
     vec![

--- a/execution/src/tests/gas_cost.rs
+++ b/execution/src/tests/gas_cost.rs
@@ -9,14 +9,14 @@ fn test_treasury_charges_l1_and_l2_cost_to_sender_account_on_success() {
 
     // Mint tokens in sender account
     let sender = EVM_ADDRESS;
-    let mint_amount = one_eth();
+    let mint_amount = one_eth() * U256::from(100);
     ctx.deposit_eth(sender, mint_amount);
 
     // Transfer to receiver account
     let l1_cost = 1;
     // Set a gas limit higher than the cost of operation
     let l2_gas_limit = 100_000;
-    let l2_gas_price = U256::from(1);
+    let l2_gas_price = U256::from(10).pow(U256::from(9)); // 1 Gwei
     let receiver = ALT_EVM_ADDRESS;
     let transfer_amount = mint_amount.wrapping_shr(2);
 
@@ -29,7 +29,7 @@ fn test_treasury_charges_l1_and_l2_cost_to_sender_account_on_success() {
             l2_gas_price,
         )
         .expect("Transfer should succeed");
-    assert!(outcome.vm_outcome.is_ok());
+    outcome.vm_outcome.unwrap();
 
     let l2_cost = outcome
         .gas_used

--- a/execution/src/tests/res/hello-strings/sources/hello_strings.move
+++ b/execution/src/tests/res/hello-strings/sources/hello_strings.move
@@ -1,8 +1,22 @@
 module 0x8fd379246834eac74b8419ffda202cf8051f7a03::hello_strings {
     use 0x1::string::{Self, String};
 
+    /// Resource that wraps a string
+    struct Msg has key { value: String }
+
     public entry fun main(name: String) {
         let greeting = string::utf8(b"Hello, ");
         string::append(&mut greeting, name);
+    }
+
+    /// Create Msg resource on an account
+    public entry fun publish(account: &signer, msg: String) {
+        move_to(account, Msg { value: msg })
+    }
+
+    /// Change an existing Msg resource
+    public entry fun update(addr: address, new_msg: String) acquires Msg {
+        let msg_ref = &mut borrow_global_mut<Msg>(addr).value;
+        *msg_ref = new_msg;
     }
 }

--- a/execution/src/tests/signer.rs
+++ b/execution/src/tests/signer.rs
@@ -1,6 +1,6 @@
 use alloy::signers::local::PrivateKeySigner;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Signer {
     pub inner: PrivateKeySigner,
     pub nonce: u64,

--- a/execution/src/tests/utils.rs
+++ b/execution/src/tests/utils.rs
@@ -294,58 +294,64 @@ impl TestContext {
         let l1_cost = U256::from(tx.l1_cost);
 
         match &tx.base_token {
-            TestBaseToken::Empty => execute_transaction(match &tx.tx {
-                NormalizedExtendedTxEnvelope::Canonical(tx) => CanonicalExecutionInput {
-                    tx,
-                    tx_hash: &tx_hash,
-                    state: self.state.resolver(),
-                    storage_trie: &self.evm_storage,
-                    genesis_config: &self.genesis_config,
-                    l1_cost: U256::ZERO,
-                    l2_fee,
-                    l2_input: l2_gas_input,
-                    base_token: &(),
-                    block_header: Default::default(),
-                    block_hash_lookup: &(),
-                }
-                .into(),
-                NormalizedExtendedTxEnvelope::DepositedTx(tx) => DepositExecutionInput {
-                    tx,
-                    tx_hash: &tx_hash,
-                    state: self.state.resolver(),
-                    storage_trie: &self.evm_storage,
-                    genesis_config: &self.genesis_config,
-                    block_header: Default::default(),
-                    block_hash_lookup: &(),
-                }
-                .into(),
-            }),
-            TestBaseToken::Umi(umi_base_token) => execute_transaction(match &tx.tx {
-                NormalizedExtendedTxEnvelope::Canonical(tx) => CanonicalExecutionInput {
-                    tx,
-                    tx_hash: &tx_hash,
-                    state: self.state.resolver(),
-                    storage_trie: &self.evm_storage,
-                    genesis_config: &self.genesis_config,
-                    l1_cost,
-                    l2_fee,
-                    l2_input: l2_gas_input,
-                    base_token: umi_base_token,
-                    block_header: Default::default(),
-                    block_hash_lookup: &(),
-                }
-                .into(),
-                NormalizedExtendedTxEnvelope::DepositedTx(tx) => DepositExecutionInput {
-                    tx,
-                    tx_hash: &tx_hash,
-                    state: self.state.resolver(),
-                    storage_trie: &self.evm_storage,
-                    genesis_config: &self.genesis_config,
-                    block_header: Default::default(),
-                    block_hash_lookup: &(),
-                }
-                .into(),
-            }),
+            TestBaseToken::Empty => execute_transaction(
+                match &tx.tx {
+                    NormalizedExtendedTxEnvelope::Canonical(tx) => CanonicalExecutionInput {
+                        tx,
+                        tx_hash: &tx_hash,
+                        state: self.state.resolver(),
+                        storage_trie: &self.evm_storage,
+                        genesis_config: &self.genesis_config,
+                        l1_cost: U256::ZERO,
+                        l2_fee,
+                        l2_input: l2_gas_input,
+                        base_token: &(),
+                        block_header: Default::default(),
+                        block_hash_lookup: &(),
+                    }
+                    .into(),
+                    NormalizedExtendedTxEnvelope::DepositedTx(tx) => DepositExecutionInput {
+                        tx,
+                        tx_hash: &tx_hash,
+                        state: self.state.resolver(),
+                        storage_trie: &self.evm_storage,
+                        genesis_config: &self.genesis_config,
+                        block_header: Default::default(),
+                        block_hash_lookup: &(),
+                    }
+                    .into(),
+                },
+                &mut Default::default(),
+            ),
+            TestBaseToken::Umi(umi_base_token) => execute_transaction(
+                match &tx.tx {
+                    NormalizedExtendedTxEnvelope::Canonical(tx) => CanonicalExecutionInput {
+                        tx,
+                        tx_hash: &tx_hash,
+                        state: self.state.resolver(),
+                        storage_trie: &self.evm_storage,
+                        genesis_config: &self.genesis_config,
+                        l1_cost,
+                        l2_fee,
+                        l2_input: l2_gas_input,
+                        base_token: umi_base_token,
+                        block_header: Default::default(),
+                        block_hash_lookup: &(),
+                    }
+                    .into(),
+                    NormalizedExtendedTxEnvelope::DepositedTx(tx) => DepositExecutionInput {
+                        tx,
+                        tx_hash: &tx_hash,
+                        state: self.state.resolver(),
+                        storage_trie: &self.evm_storage,
+                        genesis_config: &self.genesis_config,
+                        block_header: Default::default(),
+                        block_hash_lookup: &(),
+                    }
+                    .into(),
+                },
+                &mut Default::default(),
+            ),
         }
     }
 

--- a/execution/src/tests/utils.rs
+++ b/execution/src/tests/utils.rs
@@ -250,6 +250,33 @@ impl TestContext {
         self.evm_storage.apply(outcome.changes.evm).unwrap();
     }
 
+    /// Similar to `execute` above, but allows charging gas.
+    /// Note: Does not automatically increase the signer nonce and does not apply changes.
+    pub fn execute_with_fee<'a>(
+        &self,
+        module_id: &ModuleId,
+        function: &str,
+        args: impl IntoIterator<Item = &'a MoveValue>,
+        gas_price: U256,
+        gas_limit: u64,
+    ) -> TransactionExecutionOutcome {
+        let args = args
+            .into_iter()
+            .map(|arg| bcs::to_bytes(arg).unwrap())
+            .collect();
+        let (tx_hash, tx) = create_test_tx(&mut self.signer.clone(), module_id, function, args);
+
+        let treasury_address = AccountAddress::ONE;
+        let base_token = UmiBaseTokenAccounts::new(treasury_address);
+        let mut transaction = TestTransaction::new(tx, tx_hash);
+        transaction.with_cost_and_token(0, base_token, gas_limit, gas_price);
+
+        let outcome = self.execute_tx(&transaction).unwrap();
+        // Entry function transaction should succeed
+        outcome.vm_outcome.as_ref().unwrap();
+        outcome
+    }
+
     /// Executes a Move entry function expecting it to fail
     ///
     /// # Arguments
@@ -285,7 +312,7 @@ impl TestContext {
     /// # Returns
     /// The transaction execution outcome or error
     pub(crate) fn execute_tx(
-        &mut self,
+        &self,
         tx: &TestTransaction,
     ) -> umi_shared::error::Result<TransactionExecutionOutcome> {
         let l2_fee = CreateUmiL2GasFee.with_default_gas_fee_multiplier();

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -11,8 +11,10 @@ test-doubles = []
 [dependencies]
 alloy.workspace = true
 bcs.workspace = true
+bytes.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
+move-vm-types.workspace = true
 op-alloy.workspace = true
 thiserror.workspace = true
 

--- a/shared/src/error.rs
+++ b/shared/src/error.rs
@@ -153,6 +153,8 @@ pub enum InvariantViolation {
     ScriptTransaction(ScriptTransaction),
     #[error("Mempool admitted transactions cannot be deposited")]
     MempoolTransaction,
+    #[error("State key must be created to charge gas for change set")]
+    StateKey,
 }
 
 #[derive(Debug, Error)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod error;
 pub mod iter;
 pub mod primitives;
+pub mod resolver_utils;

--- a/shared/src/resolver_utils.rs
+++ b/shared/src/resolver_utils.rs
@@ -1,0 +1,57 @@
+use {
+    bytes::Bytes,
+    move_binary_format::errors::PartialVMResult,
+    move_core_types::{
+        account_address::AccountAddress,
+        effects::ChangeSet,
+        language_storage::{ModuleId, StructTag},
+        metadata::Metadata,
+        value::MoveTypeLayout,
+    },
+    move_vm_types::resolver::{ModuleResolver, ResourceResolver},
+};
+
+pub struct ChangesBasedResolver<'a> {
+    changes: &'a ChangeSet,
+}
+
+impl<'a> ChangesBasedResolver<'a> {
+    pub fn new(changes: &'a ChangeSet) -> Self {
+        Self { changes }
+    }
+}
+
+impl ResourceResolver for ChangesBasedResolver<'_> {
+    fn get_resource_bytes_with_metadata_and_layout(
+        &self,
+        address: &AccountAddress,
+        struct_tag: &StructTag,
+        _metadata: &[Metadata],
+        _layout: Option<&MoveTypeLayout>,
+    ) -> PartialVMResult<(Option<Bytes>, usize)> {
+        let bytes = self
+            .changes
+            .accounts()
+            .get(address)
+            .and_then(|account| account.resources().get(struct_tag))
+            .and_then(|op| op.clone().ok());
+        let size = bytes.as_ref().map(|b| b.len()).unwrap_or(0);
+        Ok((bytes, size))
+    }
+}
+
+impl ModuleResolver for ChangesBasedResolver<'_> {
+    fn get_module_metadata(&self, _module_id: &ModuleId) -> Vec<Metadata> {
+        Vec::new()
+    }
+
+    fn get_module(&self, id: &ModuleId) -> PartialVMResult<Option<Bytes>> {
+        let bytes = self
+            .changes
+            .accounts()
+            .get(id.address())
+            .and_then(|account| account.modules().get(id.name()))
+            .and_then(|op| op.clone().ok());
+        Ok(bytes)
+    }
+}


### PR DESCRIPTION
### Description
Closes #364 

### Changes
- Extract changes from user's transaction before charging gas, then create a new session (with a resolver that includes the user's changes) to do the gas refund.
- Charge gas for storage usage based on changes created by user's transaction and parameters in genesis config.
- When executing canonical transactions, cache results from resolver to allow looking up the size of original values in the case they are modified. This is needed to compute gas values correctly.

### Testing
New test `test_storage_update_cost`

### Notes
While working on this I noticed we don't ever make changes for the tables extension. I created a new issue for that ( #384 ) and it will have to be done in a future PR. I mention it here because we need to charge gas for the storage changes the tables cause too, so the new functions defined in this PR will need updating.