### PR TITLE
feat(app): Add a set of non-operational dependencies

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -27,6 +27,8 @@ op-alloy.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
+umi-evm-ext.features = ["test-doubles"]
+umi-evm-ext.workspace = true
 umi-execution.features = ["test-doubles"]
 umi-execution.workspace = true
 umi-blockchain.features = ["test-doubles"]

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1,3 +1,7 @@
+pub use {
+    actor::*, dependency::*, factory::create, input::*, queue::CommandQueue, uninit::Uninitialized,
+};
+
 pub mod factory;
 
 pub(crate) mod input;
@@ -9,8 +13,6 @@ mod dependency;
 mod mempool;
 mod query;
 mod queue;
-
 #[cfg(test)]
 mod tests;
-
-pub use {actor::*, dependency::*, factory::create, input::*, queue::CommandQueue};
+mod uninit;

--- a/app/src/uninit.rs
+++ b/app/src/uninit.rs
@@ -1,0 +1,104 @@
+use {
+    crate::{Application, Dependencies},
+    std::sync::Arc,
+    umi_blockchain::{block::Eip1559GasFee, state::EthTrieStateQueries},
+    umi_evm_ext::state::InMemoryDb,
+    umi_execution::U256,
+    umi_genesis::config::GenesisConfig,
+    umi_shared::primitives::B256,
+    umi_state::InMemoryState,
+};
+
+/// A set of non-operational dependencies that can be used to satisfy a parameter list.
+pub struct Uninitialized;
+
+impl Dependencies for Uninitialized {
+    type BaseTokenAccounts = ();
+    type BlockHash = B256;
+    type BlockQueries = ();
+    type BlockRepository = ();
+    type OnPayload = crate::OnPayload<Application<Self>>;
+    type OnTx = crate::OnTx<Application<Self>>;
+    type OnTxBatch = crate::OnTxBatch<Application<Self>>;
+    type PayloadQueries = ();
+    type ReceiptQueries = ();
+    type ReceiptRepository = ();
+    type ReceiptStorage = ();
+    type SharedStorage = ();
+    type ReceiptStorageReader = ();
+    type SharedStorageReader = ();
+    type State = InMemoryState;
+    type StateQueries = EthTrieStateQueries<Vec<B256>, InMemoryDb>;
+    type StorageTrieRepository = ();
+    type TransactionQueries = ();
+    type TransactionRepository = ();
+    type BaseGasFee = Eip1559GasFee;
+    type CreateL1GasFee = U256;
+    type CreateL2GasFee = U256;
+
+    fn base_token_accounts(_genesis_config: &GenesisConfig) -> Self::BaseTokenAccounts {}
+
+    fn block_hash() -> Self::BlockHash {
+        B256::ZERO
+    }
+
+    fn block_queries() -> Self::BlockQueries {}
+
+    fn block_repository() -> Self::BlockRepository {}
+
+    fn on_payload() -> &'static Self::OnPayload {
+        &|_, _, _| {}
+    }
+
+    fn on_tx() -> &'static Self::OnTx {
+        &|_, _| {}
+    }
+
+    fn on_tx_batch() -> &'static Self::OnTxBatch {
+        &|_| {}
+    }
+
+    fn payload_queries() -> Self::PayloadQueries {}
+
+    fn receipt_queries() -> Self::ReceiptQueries {}
+
+    fn receipt_repository() -> Self::ReceiptRepository {}
+
+    fn receipt_memory(&mut self) -> Self::ReceiptStorage {}
+
+    fn shared_storage(&mut self) -> Self::SharedStorage {}
+
+    fn receipt_memory_reader(&self) -> Self::ReceiptStorageReader {}
+
+    fn shared_storage_reader(&self) -> Self::SharedStorageReader {}
+
+    fn state(&self) -> Self::State {
+        InMemoryState::default()
+    }
+
+    fn state_queries(&self, genesis_config: &GenesisConfig) -> Self::StateQueries {
+        EthTrieStateQueries::new(
+            vec![genesis_config.initial_state_root],
+            Arc::new(InMemoryDb::empty()),
+            genesis_config.initial_state_root,
+        )
+    }
+
+    fn storage_trie_repository() -> Self::StorageTrieRepository {}
+
+    fn transaction_queries() -> Self::TransactionQueries {}
+
+    fn transaction_repository() -> Self::TransactionRepository {}
+
+    fn base_gas_fee() -> Self::BaseGasFee {
+        Eip1559GasFee::default()
+    }
+
+    fn create_l1_gas_fee() -> Self::CreateL1GasFee {
+        U256::ZERO
+    }
+
+    fn create_l2_gas_fee() -> Self::CreateL2GasFee {
+        U256::ZERO
+    }
+}

--- a/blockchain/src/state/read/test_doubles.rs
+++ b/blockchain/src/state/read/test_doubles.rs
@@ -1,12 +1,14 @@
 use {
-    crate::state::{Balance, BlockHeight, Nonce, ProofResponse, StateQueries},
+    crate::state::{
+        Balance, BlockHeight, HeightToStateRootIndex, Nonce, ProofResponse, StateQueries,
+    },
     eth_trie::{EthTrie, MemoryDB},
     move_core_types::account_address::AccountAddress,
     move_table_extension::TableResolver,
     move_vm_types::resolver::MoveResolver,
-    std::sync::Arc,
+    std::{convert::Infallible, sync::Arc},
     umi_evm_ext::state::StorageTrieRepository,
-    umi_shared::primitives::U256,
+    umi_shared::primitives::{B256, U256},
     umi_state::EthTrieResolver,
 };
 
@@ -50,5 +52,21 @@ impl StateQueries for MockStateQueries {
 
     fn resolver_at(&self, _: BlockHeight) -> impl MoveResolver + TableResolver + '_ {
         EthTrieResolver::new(EthTrie::new(Arc::new(MemoryDB::new(true))))
+    }
+}
+
+impl HeightToStateRootIndex for Vec<B256> {
+    type Err = Infallible;
+
+    fn root_by_height(&self, height: BlockHeight) -> Result<Option<B256>, Self::Err> {
+        Ok(self.get(height as usize).cloned())
+    }
+
+    fn height(&self) -> Result<BlockHeight, Self::Err> {
+        Ok(self.len() as u64 - 1)
+    }
+
+    fn push_state_root(&self, _state_root: B256) -> Result<(), Self::Err> {
+        Ok(())
     }
 }

--- a/blockchain/src/state/read/tests.rs
+++ b/blockchain/src/state/read/tests.rs
@@ -8,29 +8,13 @@ use {
         module_traversal::{TraversalContext, TraversalStorage},
     },
     move_vm_types::{gas::UnmeteredGasMeter, resolver::MoveResolver},
-    std::{convert::Infallible, sync::Arc},
+    std::sync::Arc,
     umi_evm_ext::state::InMemoryStorageTrieRepository,
     umi_execution::{check_nonce, create_vm_session, mint_eth, session_id::SessionId},
     umi_genesis::{CreateMoveVm, UmiVm, config::GenesisConfig},
     umi_shared::primitives::{B256, U256},
     umi_state::{Changes, InMemoryState, InMemoryTrieDb, ResolverBasedModuleBytesStorage, State},
 };
-
-impl HeightToStateRootIndex for Vec<B256> {
-    type Err = Infallible;
-
-    fn root_by_height(&self, height: BlockHeight) -> Result<Option<B256>, Self::Err> {
-        Ok(self.get(height as usize).cloned())
-    }
-
-    fn height(&self) -> Result<BlockHeight, Self::Err> {
-        Ok(self.len() as u64 - 1)
-    }
-
-    fn push_state_root(&self, _state_root: B256) -> Result<(), Self::Err> {
-        Ok(())
-    }
-}
 
 struct StateSpy(InMemoryState, ChangeSet);
 


### PR DESCRIPTION
### Description
In an effort to implement two-step start up of the application, this change adds a set of dependencies uninitialized.

The two-steps are:
1. Start the server
2. Start the application

However, starting the server needs the application because the server has RPC handlers that want to send commands and perform queries.

Therefore, having a set of uninitialized dependencies is a way to be able to create the application without initializing. Real dependencies open the database, which is in conflict with having a secondary node instance accessing it too.

All of this is towards being able bring up two instances of the node on the same database to allow for zero-downtime deployment.

### Changes
- Add `Uninitialized`
- Implement `Dependencies` for `Uninitialized`

### Testing
:green_circle: CI