### PR TITLE
refactor(server): Add `serve` function that creates `warp` server

### DIFF
--- a/server/src/allow.rs
+++ b/server/src/allow.rs
@@ -1,0 +1,11 @@
+use umi_api::method_name::MethodName;
+
+/// Grants access to all endpoints except engine API
+pub(super) fn http(method: &MethodName) -> bool {
+    method.is_non_engine_api()
+}
+
+/// Grants access to all endpoints
+pub(super) fn auth(_method: &MethodName) -> bool {
+    true
+}


### PR DESCRIPTION
### Description
While working on different ways to distribute application and server creation, I stumbled upon this difficult to work with code path that contains duplicated code that should be shared.

This change reduces duplicated server setup code, makes it more readable and easier to work with.

### Changes
- Add `serve` function for creating `warp` server
- Delegate server setup into `serve`

### Testing
:green_circle: CI
