### PR TITLE
fix(app): Mark `Uninitialized` as a test double

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -9,6 +9,7 @@ default = []
 test-doubles = [
     "umi-blockchain/test-doubles",
     "umi-execution/test-doubles",
+    "umi-evm-ext/test-doubles",
 ]
 
 [dependencies]

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1,6 +1,6 @@
-pub use {
-    actor::*, dependency::*, factory::create, input::*, queue::CommandQueue, uninit::Uninitialized,
-};
+#[cfg(any(feature = "test-doubles", test))]
+pub use uninit::Uninitialized;
+pub use {actor::*, dependency::*, factory::create, input::*, queue::CommandQueue};
 
 pub mod factory;
 
@@ -15,4 +15,5 @@ mod query;
 mod queue;
 #[cfg(test)]
 mod tests;
+#[cfg(any(feature = "test-doubles", test))]
 mod uninit;


### PR DESCRIPTION
### Description
The `Uninitialized` set of dependencies requires test doubles but lacks the proper feature flag compiler annotations, making it fail to build without specifying the needed `test-doubles` flag.

Fixes the docker build as it does not use the `test-doubles` feature

### Changes
- Mark `uninit` module as included only if `test` or `test-doubles` feature flag is on
- Add missing `umi-evm-ext/test-doubles` feature to its `umi-app` counterpart

### Testing
:green_circle: CI
:green_circle: docker build