### PR TITLE
feat(storage-rocksdb): Remove `'static` lifetime from database references

### DIFF
--- a/storage/rocksdb/src/block.rs
+++ b/storage/rocksdb/src/block.rs
@@ -4,6 +4,7 @@ use {
         transaction,
     },
     rocksdb::{AsColumnFamilyRef, DB as RocksDb, IteratorMode, WriteBatchWithTransaction},
+    std::marker::PhantomData,
     umi_blockchain::{
         block::{BlockQueries, BlockRepository, BlockResponse, ExtendedBlock},
         transaction::ExtendedTransaction,
@@ -15,11 +16,23 @@ pub const BLOCK_COLUMN_FAMILY: &str = "block";
 pub const HEIGHT_COLUMN_FAMILY: &str = "height";
 
 #[derive(Debug)]
-pub struct RocksDbBlockRepository;
+pub struct RocksDbBlockRepository<'db>(PhantomData<&'db ()>);
 
-impl BlockRepository for RocksDbBlockRepository {
+impl Default for RocksDbBlockRepository<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RocksDbBlockRepository<'_> {
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<'db> BlockRepository for RocksDbBlockRepository<'db> {
     type Err = rocksdb::Error;
-    type Storage = &'static RocksDb;
+    type Storage = &'db RocksDb;
 
     fn add(&mut self, db: &mut Self::Storage, block: ExtendedBlock) -> Result<(), Self::Err> {
         let mut batch = WriteBatchWithTransaction::<false>::default();
@@ -52,11 +65,23 @@ impl BlockRepository for RocksDbBlockRepository {
 }
 
 #[derive(Debug, Clone)]
-pub struct RocksDbBlockQueries;
+pub struct RocksDbBlockQueries<'db>(PhantomData<&'db ()>);
 
-impl BlockQueries for RocksDbBlockQueries {
+impl Default for RocksDbBlockQueries<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RocksDbBlockQueries<'_> {
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<'db> BlockQueries for RocksDbBlockQueries<'db> {
     type Err = rocksdb::Error;
-    type Storage = &'static RocksDb;
+    type Storage = &'db RocksDb;
 
     fn by_hash(
         &self,

--- a/storage/rocksdb/src/evm.rs
+++ b/storage/rocksdb/src/evm.rs
@@ -13,18 +13,18 @@ use {
 
 #[derive(Clone)]
 pub struct RocksDbStorageTrieRepository {
-    db: &'static rocksdb::DB,
+    db: Arc<rocksdb::DB>,
 }
 
 impl RocksDbStorageTrieRepository {
-    pub fn new(db: &'static rocksdb::DB) -> Self {
+    pub fn new(db: Arc<rocksdb::DB>) -> Self {
         Self { db }
     }
 }
 
 impl StorageTrieDb for RocksDbStorageTrieRepository {
     fn db(&self, account: Address) -> Arc<StagingEthTrieDb<BoxedTrieDb>> {
-        let db = RocksEthStorageTrieDb::new(self.db, account);
+        let db = RocksEthStorageTrieDb::new(self.db.clone(), account);
 
         Arc::new(StagingEthTrieDb::new(BoxedTrieDb::new(
             EthTrieDbWithLocalError::new(EthTrieWithRocksDbError::new(db)),

--- a/storage/rocksdb/src/evm_storage_trie.rs
+++ b/storage/rocksdb/src/evm_storage_trie.rs
@@ -1,6 +1,7 @@
 use {
     eth_trie::DB,
     rocksdb::{AsColumnFamilyRef, DB as RocksDb, WriteBatchWithTransaction},
+    std::sync::Arc,
     umi_evm_ext::state::DbWithRoot,
     umi_shared::primitives::{Address, B256},
 };
@@ -8,13 +9,13 @@ use {
 pub const TRIE_COLUMN_FAMILY: &str = "evm_storage_trie";
 pub const ROOT_COLUMN_FAMILY: &str = "evm_storage_trie_root";
 
-pub struct RocksEthStorageTrieDb<'db> {
-    db: &'db RocksDb,
+pub struct RocksEthStorageTrieDb {
+    db: Arc<RocksDb>,
     account: Address,
 }
 
-impl<'db> RocksEthStorageTrieDb<'db> {
-    pub fn new(db: &'db RocksDb, account: Address) -> Self {
+impl RocksEthStorageTrieDb {
+    pub fn new(db: Arc<RocksDb>, account: Address) -> Self {
         Self { db, account }
     }
 
@@ -35,7 +36,7 @@ impl<'db> RocksEthStorageTrieDb<'db> {
     }
 }
 
-impl DbWithRoot for RocksEthStorageTrieDb<'_> {
+impl DbWithRoot for RocksEthStorageTrieDb {
     fn root(&self) -> Result<Option<B256>, rocksdb::Error> {
         Ok(self
             .db
@@ -49,7 +50,7 @@ impl DbWithRoot for RocksEthStorageTrieDb<'_> {
     }
 }
 
-impl DB for RocksEthStorageTrieDb<'_> {
+impl DB for RocksEthStorageTrieDb {
     type Error = rocksdb::Error;
 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {

--- a/storage/rocksdb/src/payload.rs
+++ b/storage/rocksdb/src/payload.rs
@@ -22,12 +22,12 @@ impl ToKey for PayloadId {
 }
 
 #[derive(Debug, Clone)]
-pub struct RocksDbPayloadQueries {
-    db: &'static RocksDb,
+pub struct RocksDbPayloadQueries<'db> {
+    db: &'db RocksDb,
 }
 
-impl RocksDbPayloadQueries {
-    pub fn new(db: &'static RocksDb) -> Self {
+impl<'db> RocksDbPayloadQueries<'db> {
+    pub fn new(db: &'db RocksDb) -> Self {
         Self { db }
     }
 
@@ -40,9 +40,9 @@ impl RocksDbPayloadQueries {
     }
 }
 
-impl PayloadQueries for RocksDbPayloadQueries {
+impl<'db> PayloadQueries for RocksDbPayloadQueries<'db> {
     type Err = rocksdb::Error;
-    type Storage = &'static RocksDb;
+    type Storage = &'db RocksDb;
 
     fn by_hash(
         &self,

--- a/storage/rocksdb/src/receipt.rs
+++ b/storage/rocksdb/src/receipt.rs
@@ -1,6 +1,7 @@
 use {
     crate::generic::{FromValue, ToValue},
     rocksdb::{AsColumnFamilyRef, DB as RocksDb, WriteBatchWithTransaction},
+    std::marker::PhantomData,
     umi_blockchain::receipt::{
         ExtendedReceipt, ReceiptQueries, ReceiptRepository, TransactionReceipt,
     },
@@ -10,11 +11,23 @@ use {
 pub const COLUMN_FAMILY: &str = "receipt";
 
 #[derive(Debug)]
-pub struct RocksDbReceiptRepository;
+pub struct RocksDbReceiptRepository<'db>(PhantomData<&'db ()>);
 
-impl ReceiptRepository for RocksDbReceiptRepository {
+impl Default for RocksDbReceiptRepository<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RocksDbReceiptRepository<'_> {
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<'db> ReceiptRepository for RocksDbReceiptRepository<'db> {
     type Err = rocksdb::Error;
-    type Storage = &'static RocksDb;
+    type Storage = &'db RocksDb;
 
     fn contains(&self, db: &Self::Storage, transaction_hash: B256) -> Result<bool, Self::Err> {
         let cf = cf(db);
@@ -40,11 +53,23 @@ impl ReceiptRepository for RocksDbReceiptRepository {
 }
 
 #[derive(Debug, Clone)]
-pub struct RocksDbReceiptQueries;
+pub struct RocksDbReceiptQueries<'db>(PhantomData<&'db ()>);
 
-impl ReceiptQueries for RocksDbReceiptQueries {
+impl Default for RocksDbReceiptQueries<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RocksDbReceiptQueries<'_> {
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<'db> ReceiptQueries for RocksDbReceiptQueries<'db> {
     type Err = rocksdb::Error;
-    type Storage = &'static RocksDb;
+    type Storage = &'db RocksDb;
 
     fn by_transaction_hash(
         &self,

--- a/storage/rocksdb/src/transaction.rs
+++ b/storage/rocksdb/src/transaction.rs
@@ -1,6 +1,7 @@
 use {
     crate::generic::{FromValue, ToValue},
     rocksdb::{AsColumnFamilyRef, DB as RocksDb, WriteBatchWithTransaction},
+    std::marker::PhantomData,
     umi_blockchain::transaction::{
         ExtendedTransaction, TransactionQueries, TransactionRepository, TransactionResponse,
     },
@@ -10,11 +11,23 @@ use {
 pub const COLUMN_FAMILY: &str = "transaction";
 
 #[derive(Debug)]
-pub struct RocksDbTransactionRepository;
+pub struct RocksDbTransactionRepository<'db>(PhantomData<&'db ()>);
 
-impl TransactionRepository for RocksDbTransactionRepository {
+impl Default for RocksDbTransactionRepository<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RocksDbTransactionRepository<'_> {
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<'db> TransactionRepository for RocksDbTransactionRepository<'db> {
     type Err = rocksdb::Error;
-    type Storage = &'static RocksDb;
+    type Storage = &'db RocksDb;
 
     fn extend(
         &mut self,
@@ -34,11 +47,23 @@ impl TransactionRepository for RocksDbTransactionRepository {
 }
 
 #[derive(Debug, Clone)]
-pub struct RocksDbTransactionQueries;
+pub struct RocksDbTransactionQueries<'db>(PhantomData<&'db ()>);
 
-impl TransactionQueries for RocksDbTransactionQueries {
+impl Default for RocksDbTransactionQueries<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RocksDbTransactionQueries<'_> {
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<'db> TransactionQueries for RocksDbTransactionQueries<'db> {
     type Err = rocksdb::Error;
-    type Storage = &'static RocksDb;
+    type Storage = &'db RocksDb;
 
     fn by_hash(
         &self,


### PR DESCRIPTION
### Description
The database is implemented as a static lazily initialized variable. This gives the possibility to take `'static` references from it, which is simpler than dealing with explicit sub-static lifetimes. However, it also makes it bound to the process and cannot be reinitialized.

### Changes
- Remove `'static` from `storage-heed`

### Testing
:green_circle: CI
