### PR TITLE
refactor(api): use geth compliant codes in `JsonRpcError`

### DIFF
--- a/api/src/json_utils.rs
+++ b/api/src/json_utils.rs
@@ -1,8 +1,4 @@
-use {
-    crate::jsonrpc::JsonRpcError,
-    serde::de::DeserializeOwned,
-    std::{any, fmt},
-};
+use {crate::jsonrpc::JsonRpcError, serde::de::DeserializeOwned, std::any};
 
 pub fn get_field(x: &serde_json::Value, name: &str) -> serde_json::Value {
     x.as_object()
@@ -27,25 +23,20 @@ pub fn deserialize<T: DeserializeOwned>(x: &serde_json::Value) -> Result<T, Json
     })
 }
 
-pub fn transaction_error<E: fmt::Debug>(e: E) -> JsonRpcError {
-    // code as defined in geth's internal/ethapi/errors.go
-    JsonRpcError::without_data(-32000, format!("Execution reverted: {e:?}"))
-}
-
 pub fn parse_params_0(request: serde_json::Value) -> Result<(), JsonRpcError> {
     let params = get_params_list(&request);
     match params {
         [] => Ok(()),
-        _ => Err(JsonRpcError::parse_error(request, "Too many params")),
+        _ => Err(JsonRpcError::too_many_params_error(request)),
     }
 }
 
 pub fn parse_params_1<T: DeserializeOwned>(request: serde_json::Value) -> Result<T, JsonRpcError> {
     let params = get_params_list(&request);
     match params {
-        [] => Err(JsonRpcError::parse_error(request, "Not enough params")),
+        [] => Err(JsonRpcError::not_enough_params_error(request)),
         [x] => Ok(deserialize(x)?),
-        _ => Err(JsonRpcError::parse_error(request, "Too many params")),
+        _ => Err(JsonRpcError::too_many_params_error(request)),
     }
 }
 
@@ -56,9 +47,9 @@ where
 {
     let params = get_params_list(&request);
     match params {
-        [] | [_] => Err(JsonRpcError::parse_error(request, "Not enough params")),
+        [] | [_] => Err(JsonRpcError::not_enough_params_error(request)),
         [a, b] => Ok((deserialize(a)?, deserialize(b)?)),
-        _ => Err(JsonRpcError::parse_error(request, "Too many params")),
+        _ => Err(JsonRpcError::too_many_params_error(request)),
     }
 }
 
@@ -70,8 +61,8 @@ where
 {
     let params = get_params_list(&request);
     match params {
-        [] | [_] | [_, _] => Err(JsonRpcError::parse_error(request, "Not enough params")),
+        [] | [_] | [_, _] => Err(JsonRpcError::not_enough_params_error(request)),
         [a, b, c] => Ok((deserialize(a)?, deserialize(b)?, deserialize(c)?)),
-        _ => Err(JsonRpcError::parse_error(request, "Too many params")),
+        _ => Err(JsonRpcError::too_many_params_error(request)),
     }
 }

--- a/api/src/jsonrpc.rs
+++ b/api/src/jsonrpc.rs
@@ -1,4 +1,8 @@
-use std::fmt;
+use std::fmt::Display;
+
+use umi_shared::error::UserError;
+
+use crate::schema;
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize)]
 pub struct JsonRpcError {
@@ -8,25 +12,132 @@ pub struct JsonRpcError {
 }
 
 impl JsonRpcError {
-    pub fn without_data(code: i64, message: impl Into<String>) -> Self {
+    pub fn without_data(code: i64, message: impl Display) -> Self {
         Self {
             code,
-            message: message.into(),
+            message: format!("{}", message),
             data: serde_json::Value::Null,
         }
     }
 
-    pub fn parse_error(request: serde_json::Value, message: impl Into<String>) -> Self {
+    pub fn parse_error(request: serde_json::Value, message: impl Display) -> Self {
         Self {
+            // invalid params code as defined in geth's beacon/engine/errors.go
             code: -32602,
-            message: message.into(),
+            message: format!("{}", message),
             data: request,
         }
     }
 
-    pub fn block_not_found<T: fmt::Display>(block_number: T) -> Self {
-        // code as defined in geth's internal/ethapi/errors.go
+    pub fn too_many_params_error(request: serde_json::Value) -> Self {
+        Self::parse_error(request, "Too many params")
+    }
+
+    pub fn not_enough_params_error(request: serde_json::Value) -> Self {
+        Self::parse_error(request, "Not enough params")
+    }
+
+    pub fn missing_method(request: serde_json::Value) -> Self {
+        Self::parse_error(request, "method field not found")
+    }
+
+    pub fn invalid_method(method_name: impl Display) -> Self {
+        Self::without_data(
+            -32601,
+            format!("Invalid or unimplemented method: {method_name}"),
+        )
+    }
+
+    pub fn block_not_found(block_number: impl Display) -> Self {
+        // block number invalid code as defined in geth's internal/ethapi/errors.go
         Self::without_data(-38020, format!("Block not found: {block_number}"))
+    }
+
+    pub fn unknown_payload(payload_id: schema::PayloadId) -> Self {
+        // code as defined in geth's beacon/engine/errors.go
+        Self {
+            code: -38001,
+            data: serde_json::to_value(payload_id).expect("Must serialize payload id"),
+            message: "Unknown payload".into(),
+        }
+    }
+
+    pub fn internal_error(error: impl Display) -> Self {
+        Self::without_data(
+            // internal error code as defined in geth's internal/ethapi/errors.go
+            -32603,
+            format!("Internal error: {error}"),
+        )
+    }
+
+    pub fn transaction_error(error: impl Display) -> JsonRpcError {
+        // code as defined in geth's internal/ethapi/errors.go
+        JsonRpcError::without_data(-32000, format!("Execution reverted: {error}"))
+    }
+}
+
+impl From<umi_shared::error::Error> for JsonRpcError {
+    fn from(value: umi_shared::error::Error) -> Self {
+        match value {
+            umi_shared::error::Error::User(user_error) => match user_error {
+                e if matches!(e, UserError::Vm(_) | UserError::PartialVm(_)) => Self::without_data(
+                    // VM error code
+                    -32015, e,
+                ),
+                e if matches!(
+                    e,
+                    UserError::InvalidBlockHeight(_)
+                        | UserError::InvalidBlockHash(_)
+                        | UserError::InvalidBlockCount(_)
+                ) =>
+                {
+                    Self::block_not_found(e)
+                }
+
+                UserError::InvalidPayloadId(id) => {
+                    Self::unknown_payload(schema::PayloadId::new(id))
+                }
+                ref e @ UserError::InvalidRewardPercentiles(ref reward) => {
+                    Self::parse_error(reward.clone().into(), e)
+                }
+                other => Self::transaction_error(other),
+            },
+            umi_shared::error::Error::InvalidTransaction(invalid_transaction_cause) => {
+                match invalid_transaction_cause {
+                    e @ umi_shared::error::InvalidTransactionCause::IncorrectNonce {
+                        expected,
+                        given,
+                    } => {
+                        if expected < given {
+                            // nonce too high error code
+                            Self::without_data(-38011, e)
+                        } else {
+                            // nonce too low error code
+                            Self::without_data(-38010, e)
+                        }
+                    }
+                    e @ umi_shared::error::InvalidTransactionCause::ExhaustedAccount => {
+                        // still counts as nonce being too high
+                        Self::without_data(-38011, e)
+                    }
+                    e @ umi_shared::error::InvalidTransactionCause::InsufficientIntrinsicGas => {
+                        Self::without_data(-38013, e)
+                    }
+                    e if matches!(
+                        e,
+                        umi_shared::error::InvalidTransactionCause::FailedToPayL1Fee
+                            | umi_shared::error::InvalidTransactionCause::FailedToPayL2Fee
+                    ) =>
+                    {
+                        // insufficient funds error code
+                        Self::without_data(-38014, e)
+                    }
+                    other => Self::transaction_error(other),
+                }
+            }
+            e @ umi_shared::error::Error::DatabaseState => Self::internal_error(e),
+            umi_shared::error::Error::InvariantViolation(e) => panic!("{e}"),
+        }
     }
 }
 

--- a/api/src/method_name.rs
+++ b/api/src/method_name.rs
@@ -57,10 +57,7 @@ impl FromStr for MethodName {
             "eth_getProof" => Self::GetProof,
             "eth_gasPrice" => Self::GasPrice,
             other => {
-                return Err(JsonRpcError::without_data(
-                    -32601,
-                    format!("Unsupported method: {other}"),
-                ));
+                return Err(JsonRpcError::invalid_method(other));
             }
         })
     }

--- a/api/src/methods/call.rs
+++ b/api/src/methods/call.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        json_utils::{parse_params_2, transaction_error},
-        jsonrpc::JsonRpcError,
-    },
+    crate::{json_utils::parse_params_2, jsonrpc::JsonRpcError},
     umi_app::{ApplicationReader, Dependencies},
 };
 
@@ -12,9 +9,7 @@ pub async fn execute(
 ) -> Result<serde_json::Value, JsonRpcError> {
     let (transaction, block_number) = parse_params_2(request)?;
 
-    let response = app
-        .call(transaction, block_number)
-        .map_err(transaction_error)?;
+    let response = app.call(transaction, block_number)?;
 
     Ok(serde_json::to_value(response).expect("Must be able to JSON-serialize response"))
 }

--- a/api/src/methods/forkchoice_updated.rs
+++ b/api/src/methods/forkchoice_updated.rs
@@ -27,11 +27,7 @@ fn parse_params_v3(
 ) -> Result<(ForkchoiceStateV1, Option<PayloadAttributesV3>), JsonRpcError> {
     let params = json_utils::get_params_list(&request);
     match params {
-        [] => Err(JsonRpcError {
-            code: -32602,
-            data: request,
-            message: "Not enough params".into(),
-        }),
+        [] => Err(JsonRpcError::not_enough_params_error(request)),
         [x] => {
             let fc_state: ForkchoiceStateV1 = json_utils::deserialize(x)?;
             Ok((fc_state, None))
@@ -41,11 +37,7 @@ fn parse_params_v3(
             let payload_attributes: Option<PayloadAttributesV3> = json_utils::deserialize(y)?;
             Ok((fc_state, payload_attributes))
         }
-        _ => Err(JsonRpcError {
-            code: -32602,
-            data: request,
-            message: "Too many params".into(),
-        }),
+        _ => Err(JsonRpcError::too_many_params_error(request)),
     }
 }
 

--- a/api/src/methods/get_balance.rs
+++ b/api/src/methods/get_balance.rs
@@ -9,9 +9,7 @@ pub async fn execute(
 ) -> Result<serde_json::Value, JsonRpcError> {
     let (address, block_number) = parse_params_2(request)?;
 
-    let response = app
-        .balance_by_height(address, block_number)
-        .map_err(|_| JsonRpcError::block_not_found(block_number))?;
+    let response = app.balance_by_height(address, block_number)?;
 
     // Format the balance as a hex string
     Ok(serde_json::Value::String(format!("0x{response:x}")))

--- a/api/src/methods/get_block_by_hash.rs
+++ b/api/src/methods/get_block_by_hash.rs
@@ -11,15 +11,14 @@ pub async fn execute(
 
     let response = app
         .block_by_hash(block_hash, include_transactions)
-        .map(GetBlockResponse::from)
-        .map_err(|_| JsonRpcError::block_not_found(block_hash))?;
+        .map(GetBlockResponse::from)?;
 
     Ok(serde_json::to_value(response).expect("Must be able to JSON-serialize response"))
 }
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::methods::tests::create_app};
+    use {super::*, crate::methods::tests::create_app, alloy::primitives::B256, std::str::FromStr};
 
     pub fn example_request() -> serde_json::Value {
         serde_json::from_str(
@@ -88,11 +87,15 @@ mod tests {
 
         let response = execute(request, &reader).await;
 
+        let block_hash =
+            B256::from_str("0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb00000")
+                .unwrap();
+
         assert_eq!(
             response.unwrap_err(),
-            JsonRpcError::block_not_found(
-                "0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb00000",
-            )
+            JsonRpcError::block_not_found(umi_shared::error::Error::User(
+                umi_shared::error::UserError::InvalidBlockHash(block_hash)
+            ))
         );
     }
 }

--- a/api/src/methods/get_block_by_number.rs
+++ b/api/src/methods/get_block_by_number.rs
@@ -11,8 +11,7 @@ pub async fn execute(
 
     let response = app
         .block_by_height(number, include_transactions)
-        .map(GetBlockResponse::from)
-        .map_err(|_| JsonRpcError::block_not_found(number))?;
+        .map(GetBlockResponse::from)?;
 
     Ok(serde_json::to_value(response).expect("Must be able to JSON-serialize response"))
 }
@@ -90,7 +89,11 @@ mod tests {
 
         let response = execute(request, &reader).await;
 
-        assert_eq!(response.unwrap_err(), JsonRpcError::block_not_found("0x5"));
+        let expected_response = JsonRpcError::block_not_found(umi_shared::error::Error::User(
+            umi_shared::error::UserError::InvalidBlockHeight(5),
+        ));
+
+        assert_eq!(response.unwrap_err(), expected_response);
     }
 
     #[tokio::test]

--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -16,12 +16,7 @@ pub async fn execute_v3(
     // Spec: https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#specification-2
     let response = app
         .payload(payload_id.into())
-        .map(GetPayloadResponseV3::from)
-        .map_err(|_| JsonRpcError {
-            code: -38001,
-            data: serde_json::to_value(payload_id).expect("Must serialize payload id"),
-            message: "Unknown payload".into(),
-        })?;
+        .map(GetPayloadResponseV3::from)?;
 
     Ok(serde_json::to_value(response).expect("Must be able to JSON-serialize response"))
 }

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -35,13 +35,7 @@ async fn inner_execute_v3(
     // TODO: in theory we should start syncing to learn about this block hash.
     let response = app
         .payload_by_block_hash(execution_payload.block_hash)
-        .map(GetPayloadResponseV3::from)
-        .map_err(|_| JsonRpcError {
-            code: -1,
-            data: serde_json::to_value(execution_payload.block_hash)
-                .expect("Must serialize block hash"),
-            message: "Unknown block hash".into(),
-        })?;
+        .map(GetPayloadResponseV3::from)?;
 
     validate_payload(
         execution_payload,

--- a/api/src/methods/send_raw_transaction.rs
+++ b/api/src/methods/send_raw_transaction.rs
@@ -17,26 +17,16 @@ pub async fn execute(
 fn parse_params(request: serde_json::Value) -> Result<TxEnvelope, JsonRpcError> {
     let params = json_utils::get_params_list(&request);
     match params {
-        [] => Err(JsonRpcError {
-            code: -32602,
-            data: request,
-            message: "Not enough params".into(),
-        }),
+        [] => Err(JsonRpcError::not_enough_params_error(request)),
         [x] => {
             let bytes: Bytes = json_utils::deserialize(x)?;
             let mut slice: &[u8] = bytes.as_ref();
-            let tx = TxEnvelope::decode(&mut slice).map_err(|e| JsonRpcError {
-                code: -32602,
-                data: request,
-                message: format!("RLP decode failed: {e:?}"),
+            let tx = TxEnvelope::decode(&mut slice).map_err(|e| {
+                JsonRpcError::parse_error(request, format!("RLP decode failed: {e}"))
             })?;
             Ok(tx)
         }
-        _ => Err(JsonRpcError {
-            code: -32602,
-            data: request,
-            message: "Too many params".into(),
-        }),
+        _ => Err(JsonRpcError::too_many_params_error(request)),
     }
 }
 

--- a/api/src/request.rs
+++ b/api/src/request.rs
@@ -45,11 +45,11 @@ async fn inner_handle_request(
 
     let method: MethodName = json_utils::get_field(&request, "method")
         .as_str()
-        .ok_or(JsonRpcError::without_data(-32601, "Invalid/missing method"))?
+        .ok_or(JsonRpcError::missing_method(request.clone()))?
         .parse()?;
 
     if !is_allowed(&method) {
-        return Err(JsonRpcError::without_data(-32601, "Invalid/missing method"));
+        return Err(JsonRpcError::missing_method(request));
     }
 
     match method {

--- a/app/src/mempool.rs
+++ b/app/src/mempool.rs
@@ -66,15 +66,9 @@ impl Mempool {
     /// Recovers the signer of the transaction to use as a mempool key.
     fn get_tx_signer(&self, tx: &PendingTransaction) -> Result<Address, Error> {
         match &tx.inner {
-            OpTxEnvelope::Legacy(signed) => signed
-                .recover_signer()
-                .map_err(|_| InvalidTransactionCause::InvalidSigner.into()),
-            OpTxEnvelope::Eip2930(signed) => signed
-                .recover_signer()
-                .map_err(|_| InvalidTransactionCause::InvalidSigner.into()),
-            OpTxEnvelope::Eip1559(signed) => signed
-                .recover_signer()
-                .map_err(|_| InvalidTransactionCause::InvalidSigner.into()),
+            OpTxEnvelope::Legacy(signed) => Ok(signed.recover_signer()?),
+            OpTxEnvelope::Eip2930(signed) => Ok(signed.recover_signer()?),
+            OpTxEnvelope::Eip1559(signed) => Ok(signed.recover_signer()?),
             // EVM account abstraction not planned to be supported
             OpTxEnvelope::Eip7702(_) => Err(Error::InvalidTransaction(
                 InvalidTransactionCause::UnsupportedType,

--- a/app/src/query.rs
+++ b/app/src/query.rs
@@ -90,13 +90,20 @@ impl<D: Dependencies> ApplicationReader<D> {
         // of 100 elements
         if let Some(reward) = &reward_percentiles {
             if reward.len() > MAX_PERCENTILE_COUNT {
-                return Err(Error::User(UserError::RewardPercentilesTooLong));
+                return Err(Error::User(UserError::RewardPercentilesTooLong {
+                    max: MAX_PERCENTILE_COUNT,
+                    given: reward.len(),
+                }));
             }
             if reward.windows(2).any(|w| w[0] > w[1]) {
-                return Err(Error::User(UserError::InvalidRewardPercentiles));
+                return Err(Error::User(UserError::InvalidRewardPercentiles(
+                    reward.clone(),
+                )));
             }
             if reward.first() < Some(&0.0) || reward.last() > Some(&100.0) {
-                return Err(Error::User(UserError::InvalidRewardPercentiles));
+                return Err(Error::User(UserError::InvalidRewardPercentiles(
+                    reward.clone(),
+                )));
             }
         }
 

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -585,10 +585,10 @@ fn test_txs_from_one_account_have_proper_nonce_ordering() {
 
 #[test_case(0, None => matches Err(Error::User(UserError::InvalidBlockCount(0))); "zero block count")]
 #[test_case(5, None => matches Ok(_); "block count too long")]
-#[test_case(1, Some(vec![0.0; 101]) => matches Err(Error::User(UserError::RewardPercentilesTooLong)); "too many percentiles")]
-#[test_case(1, Some(vec![50.0, 101.0]) => matches Err(Error::User(UserError::InvalidRewardPercentiles)); "percentile out of range")]
-#[test_case(1, Some(vec![-5.0]) => matches Err(Error::User(UserError::InvalidRewardPercentiles)); "negative percentile")]
-#[test_case(1, Some(vec![75.0, 25.0, 50.0]) => matches Err(Error::User(UserError::InvalidRewardPercentiles)); "unsorted percentiles")]
+#[test_case(1, Some(vec![0.0; 101]) => matches Err(Error::User(UserError::RewardPercentilesTooLong{max: 100, given: 101})); "too many percentiles")]
+#[test_case(1, Some(vec![50.0, 101.0]) => matches Err(Error::User(UserError::InvalidRewardPercentiles(_))); "percentile out of range")]
+#[test_case(1, Some(vec![-5.0]) => matches Err(Error::User(UserError::InvalidRewardPercentiles(_))); "negative percentile")]
+#[test_case(1, Some(vec![75.0, 25.0, 50.0]) => matches Err(Error::User(UserError::InvalidRewardPercentiles(_))); "unsorted percentiles")]
 #[test_case(1, Some(vec![25.0, 50.0, 75.0]) => matches Ok(_); "valid percentiles")]
 #[test_case(1, None => matches Ok(_); "no percentiles")]
 fn test_fee_history_validation(

--- a/shared/src/error.rs
+++ b/shared/src/error.rs
@@ -77,7 +77,7 @@ pub enum UserError {
     Vm(#[from] VMError),
     #[error("{0}")]
     PartialVm(#[from] PartialVMError),
-    #[error("{0}")]
+    #[error("Could not recover tx signer: {0}")]
     InvalidSignature(#[from] alloy::primitives::SignatureError),
     #[error("Error during EVM execution for L2 bridge {0:?}")]
     DepositFailure(Vec<u8>),
@@ -94,9 +94,9 @@ pub enum UserError {
     #[error("Invalid payload id requested: {0}")]
     InvalidPayloadId(u64),
     #[error("Fee history reward percentiles were malformed")]
-    InvalidRewardPercentiles,
-    #[error("Fee history reward percentiles vector was too long")]
-    RewardPercentilesTooLong,
+    InvalidRewardPercentiles(Vec<f64>),
+    #[error("Fee history reward percentiles vector was too long: max allowed={max}, given={given}")]
+    RewardPercentilesTooLong { max: usize, given: usize },
     #[error("Invalid address requested: {0}")]
     InvalidAddress(Address),
 }
@@ -140,8 +140,6 @@ pub enum InvalidTransactionCause {
     FailedToPayL1Fee,
     #[error("Failed to pay L2 fee")]
     FailedToPayL2Fee,
-    #[error("Failed to recover tx signer")]
-    FailedToRecoverSigner,
 }
 
 impl From<InvalidTransactionCause> for Error {
@@ -283,7 +281,7 @@ mod tests {
     )]
     #[test_case(
         alloy::primitives::SignatureError::InvalidParity(0),
-        "invalid parity: 0"
+        "Could not recover tx signer: invalid parity: 0"
     )]
     #[test_case(bcs::Error::Eof, "unexpected end of input")]
     #[test_case(


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
As mentioned in the discussion with @code-dogg, current treatment of `shared::Error` to `JsonRpcError` conversion was subpar, with no panicking on invariant violation and cumbersome error mapping. This PR collects all those conversions into one place and refactors some of the surrounding infrastructure around JSON RPC errors.
<!-- Fixes #123 -->

### Changes
<!-- Key changes -->
- More idiomatic error conversion at API execution sites
- Geth-compliant error code mapping
- Slightly reworked fee history errors

### Testing
<!-- How was it tested? -->
🟢 Existing API tests

### Notes
<!-- Additional info -->