### PR TITLE
Fix(integration): Parse block info better for new version of cast

### DIFF
--- a/server/src/tests/config.sh
+++ b/server/src/tests/config.sh
@@ -9,8 +9,8 @@ set -eu
 
 # Get the finalized block timestamp and hash
 block=$(cast block finalized --rpc-url "$L1_RPC_URL")
-timestamp=$(echo "$block" | awk '/timestamp/ { print $2 }')
-blockhash=$(echo "$block" | awk '/hash/ { print $2 }')
+timestamp=$(echo "$block" | awk '/^timestamp/ { print $2 }')
+blockhash=$(echo "$block" | awk '/^hash/ { print $2 }')
 
 # Generate the config file
 config=$(cat << EOL


### PR DESCRIPTION
### Description
Newer version of `cast` command in `foundry` displays the block info with all the transactions and transactions also have `hash` info, so the parsing for the `hash` returns 2 values instead of 1. The transaction details are tabbed, so this change picks the block hash by making sure the  `hash` text searched begins without any tabs.

### Changes
- Change integration config generation bash file to pick the correct block hash value

### Testing
Integration test handles config generation correctly with this change. You need the newer version of `foundry` to see the failure.