### PR TITLE
build(docker): Alter `docker-compose.yml` to work with swarm mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     deploy:
       replicas: 0
     networks:
-      - auth-network
+      - localnet
 
   op-node:
     image: umi-op-node:latest
@@ -27,7 +27,7 @@ services:
     environment:
       JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
     networks:
-      - auth-network
+      - localnet
     depends_on:
       - optimism
       - foundry
@@ -40,7 +40,7 @@ services:
       context: ./
       dockerfile: ./docker/Dockerfile.op-batcher
     networks:
-      - auth-network
+      - localnet
     depends_on:
       - optimism
       - foundry
@@ -53,7 +53,7 @@ services:
       context: ./
       dockerfile: ./docker/Dockerfile.op-proposer
     networks:
-      - auth-network
+      - localnet
     depends_on:
       - optimism
       - foundry
@@ -68,7 +68,7 @@ services:
     environment:
       JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
     networks:
-      - auth-network
+      - localnet
     depends_on:
       - optimism
       - foundry
@@ -83,9 +83,9 @@ services:
     environment:
       JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
       OP_GETH_ADDR: "op-geth"
-      PURGE: ${PURGE:-1}
+      PURGE: ${PURGE:-0}
     networks:
-      - auth-network
+      - localnet
     volumes:
       - ./docker/volumes/shared:/volume/shared
       - ./docker/volumes/db:/volume/db
@@ -120,12 +120,12 @@ services:
       context: ./
       dockerfile: ./docker/Dockerfile.geth
     networks:
-      - auth-network
+      - localnet
     depends_on:
       - foundry
     ports:
       - "58138:58138"
 
 networks:
-  auth-network:
+  localnet:
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-name: umi
-
 services:
   foundry:
     image: umi-foundry:latest
@@ -19,7 +17,7 @@ services:
     deploy:
       replicas: 0
     networks:
-      - localnet
+      - auth-network
 
   op-node:
     image: umi-op-node:latest
@@ -29,7 +27,7 @@ services:
     environment:
       JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
     networks:
-      - localnet
+      - auth-network
     depends_on:
       - optimism
       - foundry
@@ -42,7 +40,7 @@ services:
       context: ./
       dockerfile: ./docker/Dockerfile.op-batcher
     networks:
-      - localnet
+      - auth-network
     depends_on:
       - optimism
       - foundry
@@ -55,7 +53,7 @@ services:
       context: ./
       dockerfile: ./docker/Dockerfile.op-proposer
     networks:
-      - localnet
+      - auth-network
     depends_on:
       - optimism
       - foundry
@@ -70,7 +68,7 @@ services:
     environment:
       JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
     networks:
-      - localnet
+      - auth-network
     depends_on:
       - optimism
       - foundry
@@ -87,12 +85,34 @@ services:
       OP_GETH_ADDR: "op-geth"
       PURGE: ${PURGE:-1}
     networks:
-      - localnet
+      - auth-network
     volumes:
       - ./docker/volumes/shared:/volume/shared
       - ./docker/volumes/db:/volume/db
     ports:
       - "8545:8545"
+    deploy:
+      replicas: 1
+      update_config:
+        order: start-first
+        failure_action: rollback
+        delay: 10s
+      rollback_config:
+        parallelism: 1
+        order: start-first
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'wget',
+          '--no-verbose',
+          '--tries=1',
+          '--spider',
+          'http://0.0.0.0:8545/',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   geth:
     image: umi-geth:latest
@@ -100,12 +120,12 @@ services:
       context: ./
       dockerfile: ./docker/Dockerfile.geth
     networks:
-      - localnet
+      - auth-network
     depends_on:
       - foundry
     ports:
       - "58138:58138"
 
 networks:
-  localnet:
-    driver: bridge
+  auth-network:
+    external: true

--- a/docker/host/balance.sh
+++ b/docker/host/balance.sh
@@ -5,7 +5,8 @@
 
 set -eux
 L2_RPC_URL="http://0.0.0.0:8545"
-FROM_WALLET=$(docker compose exec geth ls l1_datadir/keystore | grep -o '.\{40\}$')
+# FROM_WALLET=$(docker compose exec geth ls l1_datadir/keystore | grep -o '.\{40\}$')
+FROM_WALLET=$(docker exec $(docker ps -q -f name=moved_geth) ls l1_datadir/keystore | grep -o '.\{40\}$')
 
 BALANCE=$(curl "${L2_RPC_URL}" \
     -s \

--- a/docker/host/balance.sh
+++ b/docker/host/balance.sh
@@ -5,8 +5,7 @@
 
 set -eux
 L2_RPC_URL="http://0.0.0.0:8545"
-# FROM_WALLET=$(docker compose exec geth ls l1_datadir/keystore | grep -o '.\{40\}$')
-FROM_WALLET=$(docker exec $(docker ps -q -f name=moved_geth) ls l1_datadir/keystore | grep -o '.\{40\}$')
+FROM_WALLET=$(docker exec $(docker ps -q -f name=umi_geth) ls l1_datadir/keystore | grep -o '.\{40\}$')
 
 BALANCE=$(curl "${L2_RPC_URL}" \
     -s \

--- a/docker/host/deposit.sh
+++ b/docker/host/deposit.sh
@@ -7,8 +7,10 @@
 
 set -eux
 L1_RPC_URL="http://0.0.0.0:58138"
-FROM_WALLET=$(docker compose exec geth ls l1_datadir/keystore | grep -o '.\{40\}$')
-BRIDGE_ADDRESS=$(docker compose exec op-node cat packages/contracts-bedrock/deployments/1337-deploy.json | jq -r .L1StandardBridgeProxy)
+# FROM_WALLET=$(docker compose exec geth ls l1_datadir/keystore | grep -o '.\{40\}$')
+FROM_WALLET=$(docker exec $(docker ps -q -f name=moved_geth) ls l1_datadir/keystore | grep -o '.\{40\}$')
+# BRIDGE_ADDRESS=$(docker compose exec op-node cat packages/contracts-bedrock/deployments/1337-deploy.json | jq -r .L1StandardBridgeProxy)
+BRIDGE_ADDRESS=$(docker exec $(docker ps -q -f name=moved_op-node) cat packages/contracts-bedrock/deployments/1337-deploy.json | jq -r .L1StandardBridgeProxy)
 AMOUNT=1000000000000000000
 
 NONCE=$(curl "${L1_RPC_URL}" \

--- a/docker/host/deposit.sh
+++ b/docker/host/deposit.sh
@@ -7,10 +7,8 @@
 
 set -eux
 L1_RPC_URL="http://0.0.0.0:58138"
-# FROM_WALLET=$(docker compose exec geth ls l1_datadir/keystore | grep -o '.\{40\}$')
-FROM_WALLET=$(docker exec $(docker ps -q -f name=moved_geth) ls l1_datadir/keystore | grep -o '.\{40\}$')
-# BRIDGE_ADDRESS=$(docker compose exec op-node cat packages/contracts-bedrock/deployments/1337-deploy.json | jq -r .L1StandardBridgeProxy)
-BRIDGE_ADDRESS=$(docker exec $(docker ps -q -f name=moved_op-node) cat packages/contracts-bedrock/deployments/1337-deploy.json | jq -r .L1StandardBridgeProxy)
+FROM_WALLET=$(docker exec $(docker ps -q -f name=umi_geth) ls l1_datadir/keystore | grep -o '.\{40\}$')
+BRIDGE_ADDRESS=$(docker exec $(docker ps -q -f name=umi_op-node) cat packages/contracts-bedrock/deployments/1337-deploy.json | jq -r .L1StandardBridgeProxy)
 AMOUNT=1000000000000000000
 
 NONCE=$(curl "${L1_RPC_URL}" \


### PR DESCRIPTION
### Description
Changes the docker configuration and related scripts to work with a setup that's run by swarm instead of compose.

Docker swarm allows for multi-instance stack.

### Changes
- Change `localnet` network to be external, which should have an overlay driver and a swarm scope
- Remove `name` as that is not supported
- Add a `deploy` configuration to allow for zero downtime deployments
- Add a `heathcheck` to allow for verification that the newly deployed instance is ready

### Testing
:green_circle: Docker