### PR TITLE
Fix(integration-test): EVM storage and missing transaction handling

### DIFF
--- a/api/src/methods/get_transaction_by_hash.rs
+++ b/api/src/methods/get_transaction_by_hash.rs
@@ -10,8 +10,8 @@ pub async fn execute(
     let tx_hash = parse_params_1(request)?;
 
     let response = app
-        .transaction_by_hash(tx_hash)
-        .map(GetTransactionResponse::from)?;
+        .transaction_by_hash(tx_hash)?
+        .map(GetTransactionResponse::from);
 
     Ok(serde_json::to_value(response).expect("Must be able to JSON-serialize response"))
 }
@@ -24,9 +24,8 @@ mod tests {
             methods::{forkchoice_updated, get_payload, send_raw_transaction, tests::create_app},
             schema::{ForkchoiceUpdatedResponseV1, GetPayloadResponseV3},
         },
-        alloy::primitives::B256,
         serde_json::json,
-        std::{iter, str::FromStr},
+        std::iter,
     };
 
     #[tokio::test]
@@ -45,16 +44,8 @@ mod tests {
 
         let response = execute(request, &reader).await;
 
-        let block_hash =
-            B256::from_str("0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb00000")
-                .unwrap();
-
-        assert_eq!(
-            response.unwrap_err(),
-            JsonRpcError::block_not_found(umi_shared::error::Error::User(
-                umi_shared::error::UserError::InvalidBlockHash(block_hash)
-            ))
-        );
+        // A missing transaction is not an error, just a null response.
+        assert_eq!(response.unwrap(), serde_json::Value::Null);
     }
 
     #[tokio::test]

--- a/api/src/methods/get_transaction_receipt.rs
+++ b/api/src/methods/get_transaction_receipt.rs
@@ -22,8 +22,7 @@ mod tests {
             methods::{forkchoice_updated, get_payload, send_raw_transaction, tests::create_app},
             schema::{ForkchoiceUpdatedResponseV1, GetPayloadResponseV3},
         },
-        alloy::primitives::B256,
-        std::{iter, str::FromStr},
+        std::iter,
         umi_blockchain::receipt::TransactionReceipt,
     };
 
@@ -43,16 +42,8 @@ mod tests {
 
         let response = execute(request, &reader).await;
 
-        let block_hash =
-            B256::from_str("0xe56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb00000")
-                .unwrap();
-
-        assert_eq!(
-            response.unwrap_err(),
-            JsonRpcError::block_not_found(umi_shared::error::Error::User(
-                umi_shared::error::UserError::InvalidBlockHash(block_hash)
-            ))
-        );
+        // A missing transaction is not an error, just a null response.
+        assert_eq!(response.unwrap(), serde_json::Value::Null);
     }
 
     #[tokio::test]

--- a/app/src/dependency.rs
+++ b/app/src/dependency.rs
@@ -50,7 +50,7 @@ impl<D: Dependencies> ApplicationReader<D> {
             receipt_memory: deps.receipt_memory_reader(),
             storage: deps.shared_storage_reader(),
             state_queries: deps.state_queries(genesis_config),
-            evm_storage: D::storage_trie_repository(),
+            evm_storage: deps.storage_trie_repository(),
             transaction_queries: D::transaction_queries(),
         }
     }
@@ -111,7 +111,7 @@ impl<D: Dependencies> Application<D> {
             storage_reader: deps.shared_storage_reader(),
             state: deps.state(),
             state_queries: deps.state_queries(genesis_config),
-            evm_storage: D::storage_trie_repository(),
+            evm_storage: deps.storage_trie_repository(),
             transaction_queries: D::transaction_queries(),
             transaction_repository: D::transaction_repository(),
             resolver_cache: ResolverCache::default(),
@@ -249,7 +249,7 @@ pub trait Dependencies {
 
     fn state_queries(&self, genesis_config: &GenesisConfig) -> Self::StateQueries;
 
-    fn storage_trie_repository() -> Self::StorageTrieRepository;
+    fn storage_trie_repository(&self) -> Self::StorageTrieRepository;
 
     fn transaction_queries() -> Self::TransactionQueries;
 
@@ -444,7 +444,7 @@ mod test_doubles {
             unimplemented!("Dependencies are created manually in tests")
         }
 
-        fn storage_trie_repository() -> Self::StorageTrieRepository {
+        fn storage_trie_repository(&self) -> Self::StorageTrieRepository {
             unimplemented!("Dependencies are created manually in tests")
         }
 

--- a/app/src/query.rs
+++ b/app/src/query.rs
@@ -212,12 +212,11 @@ impl<D: Dependencies> ApplicationReader<D> {
         transaction: TransactionRequest,
         block_number: BlockNumberOrTag,
     ) -> Result<u64> {
-        let height = self.resolve_height(block_number)?;
         let block_height = self.resolve_height(block_number)?;
         let block_hash_lookup = StorageBasedProvider::new(&self.storage, &self.block_queries);
         let outcome = simulate_transaction(
             transaction,
-            &self.state_queries.resolver_at(height)?,
+            &self.state_queries.resolver_at(block_height)?,
             &self.evm_storage,
             &self.genesis_config,
             &self.base_token,

--- a/app/src/query.rs
+++ b/app/src/query.rs
@@ -248,18 +248,16 @@ impl<D: Dependencies> ApplicationReader<D> {
         )
     }
 
-    pub fn transaction_receipt(&self, tx_hash: B256) -> Result<TransactionReceipt> {
+    pub fn transaction_receipt(&self, tx_hash: B256) -> Result<Option<TransactionReceipt>> {
         self.receipt_queries
             .by_transaction_hash(&self.receipt_memory, tx_hash)
-            .map_err(|_| Error::DatabaseState)?
-            .ok_or(Error::User(UserError::InvalidBlockHash(tx_hash)))
+            .map_err(|_| Error::DatabaseState)
     }
 
-    pub fn transaction_by_hash(&self, tx_hash: B256) -> Result<TransactionResponse> {
+    pub fn transaction_by_hash(&self, tx_hash: B256) -> Result<Option<TransactionResponse>> {
         self.transaction_queries
             .by_hash(&self.storage, tx_hash)
-            .map_err(|_| Error::DatabaseState)?
-            .ok_or(Error::User(UserError::InvalidBlockHash(tx_hash)))
+            .map_err(|_| Error::DatabaseState)
     }
 
     pub fn proof(
@@ -382,6 +380,7 @@ impl<D: Dependencies> ApplicationReader<D> {
             .map(|hash| {
                 let rx = self
                     .transaction_receipt(hash)
+                    .expect("Database should work")
                     .expect("Tx receipt should exist");
                 (rx.inner.effective_gas_price, rx.inner.gas_used)
             })

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -544,7 +544,7 @@ fn test_txs_from_one_account_have_proper_nonce_ordering() {
         // Get receipt for this transaction
         let receipt = reader.transaction_receipt(*tx_hash);
 
-        let receipt = receipt.unwrap_or_else(|_| {
+        let receipt = receipt.expect("Database should work").unwrap_or_else(|| {
             panic!(
                 "Transaction with nonce {} and hash {:?} has no receipt",
                 i, tx_hash

--- a/app/src/uninit.rs
+++ b/app/src/uninit.rs
@@ -84,7 +84,7 @@ impl Dependencies for Uninitialized {
         )
     }
 
-    fn storage_trie_repository() -> Self::StorageTrieRepository {}
+    fn storage_trie_repository(&self) -> Self::StorageTrieRepository {}
 
     fn transaction_queries() -> Self::TransactionQueries {}
 

--- a/blockchain/src/block/in_memory.rs
+++ b/blockchain/src/block/in_memory.rs
@@ -1,106 +1,42 @@
 use {
     crate::{block::ExtendedBlock, payload::PayloadId},
-    std::sync::Arc,
+    std::{
+        collections::HashMap,
+        sync::{Arc, RwLock},
+    },
     umi_shared::primitives::B256,
 };
-
-pub type WriteHashes = evmap::WriteHandle<B256, Arc<ExtendedBlock>>;
-pub type ReadHashes = evmap::ReadHandle<B256, Arc<ExtendedBlock>>;
-pub type WriteHeights = evmap::WriteHandle<u64, Arc<ExtendedBlock>>;
-pub type ReadHeights = evmap::ReadHandle<u64, Arc<ExtendedBlock>>;
-pub type WritePayloadIds = evmap::WriteHandle<PayloadId, Arc<ExtendedBlock>>;
-pub type ReadPayloadIds = evmap::ReadHandle<PayloadId, Arc<ExtendedBlock>>;
 
 /// A storage for blocks that keeps data in memory.
 ///
 /// The repository keeps data stored locally and its memory is not shared outside the struct. It
 /// maintains a set of indices for efficient lookup.
-#[derive(Debug)]
+#[derive(Debug, Default, Clone)]
 pub struct BlockMemory {
-    hashes: WriteHashes,
-    heights: WriteHeights,
-    payload_ids: WritePayloadIds,
+    hashes: Arc<RwLock<HashMap<B256, Arc<ExtendedBlock>>>>,
+    heights: Arc<RwLock<HashMap<u64, Arc<ExtendedBlock>>>>,
+    payload_ids: Arc<RwLock<HashMap<PayloadId, Arc<ExtendedBlock>>>>,
 }
 
 impl BlockMemory {
-    pub const fn new(
-        hashes: WriteHashes,
-        heights: WriteHeights,
-        payload_ids: WritePayloadIds,
-    ) -> Self {
-        Self {
-            hashes,
-            heights,
-            payload_ids,
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn add(&mut self, block: ExtendedBlock) {
         let block = Arc::new(block);
-        self.hashes.insert(block.hash, block.clone());
+        self.hashes
+            .write()
+            .unwrap()
+            .insert(block.hash, block.clone());
         self.heights
+            .write()
+            .unwrap()
             .insert(block.block.header.number, block.clone());
-        self.payload_ids.insert(block.payload_id, block);
-        self.hashes.refresh();
-        self.heights.refresh();
-        self.payload_ids.refresh();
-    }
-}
-
-impl AsRef<ReadHeights> for BlockMemory {
-    fn as_ref(&self) -> &ReadHeights {
-        &self.heights
-    }
-}
-
-impl AsRef<ReadHashes> for BlockMemory {
-    fn as_ref(&self) -> &ReadHashes {
-        &self.hashes
-    }
-}
-
-impl AsRef<ReadPayloadIds> for BlockMemory {
-    fn as_ref(&self) -> &ReadPayloadIds {
-        &self.payload_ids
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct BlockMemoryReader {
-    hashes: ReadHashes,
-    heights: ReadHeights,
-    payload_ids: ReadPayloadIds,
-}
-
-impl BlockMemoryReader {
-    pub const fn new(
-        hashes: ReadHashes,
-        heights: ReadHeights,
-        payload_ids: ReadPayloadIds,
-    ) -> Self {
-        Self {
-            hashes,
-            heights,
-            payload_ids,
-        }
-    }
-}
-
-impl AsRef<ReadHeights> for BlockMemoryReader {
-    fn as_ref(&self) -> &ReadHeights {
-        &self.heights
-    }
-}
-
-impl AsRef<ReadHashes> for BlockMemoryReader {
-    fn as_ref(&self) -> &ReadHashes {
-        &self.hashes
-    }
-}
-
-impl AsRef<ReadPayloadIds> for BlockMemoryReader {
-    fn as_ref(&self) -> &ReadPayloadIds {
-        &self.payload_ids
+        self.payload_ids
+            .write()
+            .unwrap()
+            .insert(block.payload_id, block.clone());
     }
 }
 
@@ -117,26 +53,29 @@ pub trait ReadBlockMemory {
     }
 }
 
-impl<T: AsRef<ReadHashes> + AsRef<ReadHeights> + AsRef<ReadPayloadIds>> ReadBlockMemory for T {
+impl ReadBlockMemory for BlockMemory {
     fn by_hash(&self, hash: B256) -> Option<ExtendedBlock> {
-        <T as AsRef<ReadHashes>>::as_ref(self)
-            .get_one(&hash)
-            .map(|v| ExtendedBlock::clone(&v))
+        self.hashes
+            .read()
+            .unwrap()
+            .get(&hash)
+            .map(|b| ExtendedBlock::clone(b))
     }
 
     fn by_payload_id(&self, payload_id: PayloadId) -> Option<ExtendedBlock> {
-        <T as AsRef<ReadPayloadIds>>::as_ref(self)
-            .get_one(&payload_id)
-            .map(|v| ExtendedBlock::clone(&v))
+        self.payload_ids
+            .read()
+            .unwrap()
+            .get(&payload_id)
+            .map(|b| ExtendedBlock::clone(b))
     }
 
     fn map_by_height<U>(&self, height: u64, f: impl FnOnce(&'_ ExtendedBlock) -> U) -> Option<U> {
-        <T as AsRef<ReadHeights>>::as_ref(self)
-            .get_one(&height)
-            .map(|v| f(&v))
+        self.heights.read().unwrap().get(&height).map(|b| f(b))
     }
 
     fn height(&self) -> Option<u64> {
-        (<T as AsRef<ReadHeights>>::as_ref(self).len() as u64).checked_sub(1)
+        let n = self.heights.read().unwrap().len() as u64;
+        n.checked_sub(1)
     }
 }

--- a/blockchain/src/block/mod.rs
+++ b/blockchain/src/block/mod.rs
@@ -13,10 +13,7 @@ mod write;
 pub use {
     gas::{BaseGasFee, Eip1559GasFee},
     hash::{BlockHash, UmiBlockHash},
-    in_memory::{
-        BlockMemory, BlockMemoryReader, ReadBlockMemory, ReadHashes, ReadHeights, ReadPayloadIds,
-        WriteHashes, WriteHeights, WritePayloadIds,
-    },
+    in_memory::{BlockMemory, ReadBlockMemory},
     read::{BlockQueries, BlockResponse, in_memory::InMemoryBlockQueries},
     write::{Block, BlockRepository, ExtendedBlock, Header, in_memory::InMemoryBlockRepository},
 };

--- a/blockchain/src/in_memory.rs
+++ b/blockchain/src/in_memory.rs
@@ -1,17 +1,17 @@
 use crate::{
-    block::{BlockMemory, BlockMemoryReader},
+    block::BlockMemory,
     transaction::{TransactionMemory, TransactionMemoryReader},
 };
 
 #[derive(Debug, Clone)]
 pub struct SharedMemoryReader {
-    pub block_memory: BlockMemoryReader,
+    pub block_memory: BlockMemory,
     pub transaction_memory: TransactionMemoryReader,
 }
 
 impl SharedMemoryReader {
     pub const fn new(
-        block_memory: BlockMemoryReader,
+        block_memory: BlockMemory,
         transaction_memory: TransactionMemoryReader,
     ) -> Self {
         Self {
@@ -38,22 +38,18 @@ impl SharedMemory {
 
 pub mod shared_memory {
     use crate::{
-        block::{BlockMemory, BlockMemoryReader},
+        block::BlockMemory,
         in_memory::{SharedMemory, SharedMemoryReader},
         transaction::{TransactionMemory, TransactionMemoryReader},
     };
 
     pub fn new() -> (SharedMemoryReader, SharedMemory) {
-        let (r1, w1) = evmap::new();
-        let (r2, w2) = evmap::new();
-        let (r3, w3) = evmap::new();
-        let bw = BlockMemory::new(w1, w2, w3);
-        let br = BlockMemoryReader::new(r1, r2, r3);
+        let bm = BlockMemory::new();
         let (r1, w1) = evmap::new();
         let tw = TransactionMemory::new(w1);
         let tr = TransactionMemoryReader::new(r1);
-        let w = SharedMemory::new(bw, tw);
-        let r = SharedMemoryReader::new(br, tr);
+        let w = SharedMemory::new(bm.clone(), tw);
+        let r = SharedMemoryReader::new(bm, tr);
 
         (r, w)
     }

--- a/server/src/dependency/heed.rs
+++ b/server/src/dependency/heed.rs
@@ -112,7 +112,7 @@ impl umi_app::Dependencies for HeedDependencies {
         )
     }
 
-    fn storage_trie_repository() -> Self::StorageTrieRepository {
+    fn storage_trie_repository(&self) -> Self::StorageTrieRepository {
         evm::HeedStorageTrieRepository::new(Database.clone())
     }
 

--- a/server/src/dependency/in_memory.rs
+++ b/server/src/dependency/in_memory.rs
@@ -28,6 +28,7 @@ pub struct InMemoryDependencies {
     receipt_memory_reader: umi_blockchain::receipt::ReceiptMemoryReader,
     receipt_memory: Option<umi_blockchain::receipt::ReceiptMemory>,
     trie_db: Arc<umi_state::InMemoryTrieDb>,
+    evm_storage_tries: umi_evm_ext::state::InMemoryStorageTrieRepository,
 }
 
 impl InMemoryDependencies {
@@ -42,6 +43,7 @@ impl InMemoryDependencies {
             receipt_memory_reader,
             receipt_memory: Some(receipt_memory),
             trie_db: Arc::new(umi_state::InMemoryTrieDb::empty()),
+            evm_storage_tries: umi_evm_ext::state::InMemoryStorageTrieRepository::new(),
         }
     }
 
@@ -55,6 +57,7 @@ impl InMemoryDependencies {
             receipt_memory_reader: self.receipt_memory_reader.clone(),
             receipt_memory: None,
             trie_db: self.trie_db.clone(),
+            evm_storage_tries: self.evm_storage_tries.clone(),
         }
     }
 }
@@ -149,8 +152,8 @@ impl umi_app::Dependencies for InMemoryDependencies {
         )
     }
 
-    fn storage_trie_repository() -> Self::StorageTrieRepository {
-        umi_evm_ext::state::InMemoryStorageTrieRepository::new()
+    fn storage_trie_repository(&self) -> Self::StorageTrieRepository {
+        self.evm_storage_tries.clone()
     }
 
     fn transaction_queries() -> Self::TransactionQueries {

--- a/server/src/dependency/rocksdb.rs
+++ b/server/src/dependency/rocksdb.rs
@@ -111,7 +111,7 @@ impl umi_app::Dependencies for RocksDbDependencies {
         )
     }
 
-    fn storage_trie_repository() -> Self::StorageTrieRepository {
+    fn storage_trie_repository(&self) -> Self::StorageTrieRepository {
         umi_storage_rocksdb::evm::RocksDbStorageTrieRepository::new(Database.clone())
     }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use umi_blockchain::block::{Block, BlockHash, ExtendedBlock, Header};
 use {
     crate::mirror::MirrorLog,
     clap::Parser,
@@ -16,7 +14,7 @@ use {
     umi_api::method_name::MethodName,
     umi_app::{Application, ApplicationReader, Command, CommandQueue, Dependencies},
     umi_blockchain::{
-        block::BlockQueries,
+        block::{Block, BlockHash, BlockQueries, ExtendedBlock, Header},
         payload::{NewPayloadId, StatePayloadId},
     },
     umi_genesis::config::GenesisConfig,
@@ -166,11 +164,12 @@ pub fn initialize_app(
             &mut app.evm_storage,
         );
     }
+    let genesis_block = create_genesis_block(&app.block_hash, &genesis_config);
+    app.genesis_update(genesis_block);
 
     (app, app_reader)
 }
 
-#[cfg(test)]
 fn create_genesis_block(
     block_hash: &impl BlockHash,
     genesis_config: &GenesisConfig,


### PR DESCRIPTION
### Description
This PR fixes the integration so that it works again (with all backends).

### Changes
- Failing to find a transaction by hash is not an error. This is important to get right because libraries for interacting with Ethereum RPCs handle null responses differently from errors and will check for transactions by hash in a loop when waiting for a status.
- Use the same EVM account storage for both application reader and writer for the in-memory backend. This is necessary because otherwise the reader does not see the changes the writer makes. The database backends already had this property because the reader and writer refer to the same DB on-disk.
- Use `Arc<RwLock<HashMap>>` for in-memory block storage. I don't know why the `evmap` implementation doesn't work, but the integration test fails to show op_node the right genesis block (from geth), so it must have something to do with the eventual consistency.
- Create the genesis block during app initialization. This is necessary because the app panics if the block storage is ever empty, which could happen if it receives a some other request before `eth_getBlockByNumber` (which is when we steal the genesis block from op-geth.

### Testing
- Integration test.