### PR TITLE
feat(server): Add `umi-server-args` crate that declares parameters for running the server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8264,27 +8264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "optional_struct"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14199f59efce6ed2c5854f0abc725c32eedfbd02c6ef82c9733c726f3fc6dc91"
-dependencies = [
- "optional_struct_macro",
- "serde",
-]
-
-[[package]]
-name = "optional_struct_macro"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5eba042d9efe5e108e0df9ce2f85c540fc4f94f41c6821cbcf70ed47c1221da"
-dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "ouroboros"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12515,7 +12494,6 @@ dependencies = [
 name = "umi-server-args"
 version = "0.1.0"
 dependencies = [
- "optional_struct",
  "serde",
  "toml 0.8.23",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8264,6 +8264,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "optional_struct"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14199f59efce6ed2c5854f0abc725c32eedfbd02c6ef82c9733c726f3fc6dc91"
+dependencies = [
+ "optional_struct_macro",
+ "serde",
+]
+
+[[package]]
+name = "optional_struct_macro"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5eba042d9efe5e108e0df9ce2f85c540fc4f94f41c6821cbcf70ed47c1221da"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "ouroboros"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8972,7 +8993,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit 0.22.26",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -10472,9 +10493,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -11789,10 +11810,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.9"
+name = "toml"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
@@ -11824,14 +11857,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.9.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow 0.7.10",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -12467,6 +12509,15 @@ dependencies = [
  "umi-storage-rocksdb",
  "warp",
  "warp-reverse-proxy",
+]
+
+[[package]]
+name = "umi-server-args"
+version = "0.1.0"
+dependencies = [
+ "optional_struct",
+ "serde",
+ "toml 0.8.23",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,6 @@ warp = "0.3"
 warp-reverse-proxy = "1"
 evmap = "10"
 toml = "0.8"
-optional_struct = "0.5"
 
 [patch.crates-io]
 merlin = { git = "https://github.com/aptos-labs/merlin" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "genesis-builder",
     "genesis-image",
     "server",
+    "server/args",
     "shared",
     "state",
     "storage/rocksdb",
@@ -99,6 +100,8 @@ tokio = { version = "1", features = ["full"] }
 warp = "0.3"
 warp-reverse-proxy = "1"
 evmap = "10"
+toml = "0.8"
+optional_struct = "0.5"
 
 [patch.crates-io]
 merlin = { git = "https://github.com/aptos-labs/merlin" }

--- a/server/args/Cargo.toml
+++ b/server/args/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "umi-server-args"
+description = "Umi execution HTTP server settings"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+toml.workspace = true
+optional_struct.workspace = true
+serde.workspace = true

--- a/server/args/Cargo.toml
+++ b/server/args/Cargo.toml
@@ -6,5 +6,4 @@ edition = "2021"
 
 [dependencies]
 toml.workspace = true
-optional_struct.workspace = true
 serde.workspace = true

--- a/server/args/src/declaration.rs
+++ b/server/args/src/declaration.rs
@@ -1,18 +1,18 @@
 use {serde::Deserialize, std::net::SocketAddr};
 
-#[derive(Deserialize, PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Config {
     pub auth: AuthSocket,
     pub http: HttpSocket,
 }
 
-#[derive(Deserialize, PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct AuthSocket {
     pub addr: SocketAddr,
     pub jwt_secret: String,
 }
 
-#[derive(Deserialize, PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct HttpSocket {
     pub addr: SocketAddr,
 }

--- a/server/args/src/declaration.rs
+++ b/server/args/src/declaration.rs
@@ -1,0 +1,25 @@
+use {optional_struct::Applicable, serde::Deserialize, std::net::SocketAddr};
+
+#[optional_struct::optional_struct]
+#[derive(Deserialize, PartialEq, Debug, Clone)]
+pub struct Config {
+    #[optional_rename(OptionalAuthSocket)]
+    #[optional_wrap]
+    pub auth: AuthSocket,
+    #[optional_rename(OptionalHttpSocket)]
+    #[optional_wrap]
+    pub http: HttpSocket,
+}
+
+#[optional_struct::optional_struct]
+#[derive(Deserialize, PartialEq, Debug, Clone)]
+pub struct HttpSocket {
+    pub addr: SocketAddr,
+}
+
+#[optional_struct::optional_struct]
+#[derive(Deserialize, PartialEq, Debug, Clone)]
+pub struct AuthSocket {
+    pub addr: SocketAddr,
+    pub jwt_secret: String,
+}

--- a/server/args/src/declaration.rs
+++ b/server/args/src/declaration.rs
@@ -1,25 +1,35 @@
-use {optional_struct::Applicable, serde::Deserialize, std::net::SocketAddr};
+use {serde::Deserialize, std::net::SocketAddr};
 
-#[optional_struct::optional_struct]
 #[derive(Deserialize, PartialEq, Debug, Clone)]
 pub struct Config {
-    #[optional_rename(OptionalAuthSocket)]
-    #[optional_wrap]
     pub auth: AuthSocket,
-    #[optional_rename(OptionalHttpSocket)]
-    #[optional_wrap]
     pub http: HttpSocket,
 }
 
-#[optional_struct::optional_struct]
+#[derive(Deserialize, PartialEq, Debug, Clone)]
+pub struct AuthSocket {
+    pub addr: SocketAddr,
+    pub jwt_secret: String,
+}
+
 #[derive(Deserialize, PartialEq, Debug, Clone)]
 pub struct HttpSocket {
     pub addr: SocketAddr,
 }
 
-#[optional_struct::optional_struct]
 #[derive(Deserialize, PartialEq, Debug, Clone)]
-pub struct AuthSocket {
-    pub addr: SocketAddr,
-    pub jwt_secret: String,
+pub struct OptionalConfig {
+    pub auth: Option<OptionalAuthSocket>,
+    pub http: Option<OptionalHttpSocket>,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Clone)]
+pub struct OptionalAuthSocket {
+    pub addr: Option<SocketAddr>,
+    pub jwt_secret: Option<String>,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Clone)]
+pub struct OptionalHttpSocket {
+    pub addr: Option<SocketAddr>,
 }

--- a/server/args/src/lib.rs
+++ b/server/args/src/lib.rs
@@ -1,0 +1,3 @@
+mod declaration;
+#[cfg(test)]
+mod tests;

--- a/server/args/src/tests.rs
+++ b/server/args/src/tests.rs
@@ -1,0 +1,27 @@
+use crate::declaration::{OptionalAuthSocket, OptionalConfig, OptionalHttpSocket};
+
+#[test]
+fn test_config_parses_from_toml_successfully() {
+    let actual_config: OptionalConfig = toml::from_str(
+        r#"
+        [auth]
+        addr = '127.0.0.1:444'
+        jwt_secret = 'aaa'
+
+        [http]
+        addr = '127.0.0.1:445'
+    "#,
+    )
+    .unwrap();
+    let expected_config = OptionalConfig {
+        auth: Some(OptionalAuthSocket {
+            addr: Some("127.0.0.1:444".parse().unwrap()),
+            jwt_secret: Some("aaa".to_owned()),
+        }),
+        http: Some(OptionalHttpSocket {
+            addr: Some("127.0.0.1:445".parse().unwrap()),
+        }),
+    };
+
+    assert_eq!(actual_config, expected_config);
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -35,7 +35,6 @@ mod allow;
 mod dependency;
 mod geth_genesis;
 mod mirror;
-
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
### Description
Adds a small crate that declares server settings.

### Changes
- Add `umi-server-args` crate

### Testing
:green_circle: CI

### Notes
#45 