### PR TITLE
feat(server-args): Implement `Layer` that returns default values

### DIFF
--- a/server/args/src/layers/default.rs
+++ b/server/args/src/layers/default.rs
@@ -1,0 +1,46 @@
+use {
+    crate::{declaration::OptionalConfig, stack::Layer},
+    std::convert::Infallible,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct DefaultLayer(OptionalConfig);
+
+impl DefaultLayer {
+    pub const fn new(default: OptionalConfig) -> Self {
+        Self(default)
+    }
+}
+
+impl Layer for DefaultLayer {
+    type Err = Infallible;
+
+    fn try_load(self) -> Result<OptionalConfig, Self::Err> {
+        Ok(self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::declaration::{OptionalAuthSocket, OptionalHttpSocket},
+    };
+
+    #[test]
+    fn test_default_layer_passes_given_config_unchanged() {
+        let expected_config = OptionalConfig {
+            auth: Some(OptionalAuthSocket {
+                addr: "0.0.0.0:2".parse().ok(),
+                jwt_secret: Some("test".to_owned()),
+            }),
+            http: Some(OptionalHttpSocket {
+                addr: "0.0.0.0:1".parse().ok(),
+            }),
+        };
+        let layer = DefaultLayer(expected_config.clone());
+        let actual_config = layer.try_load().unwrap();
+
+        assert_eq!(actual_config, expected_config);
+    }
+}

--- a/server/args/src/layers/mod.rs
+++ b/server/args/src/layers/mod.rs
@@ -1,5 +1,6 @@
-pub use {cli::CliLayer, env::EnvLayer, file::FileLayer};
+pub use {cli::CliLayer, default::DefaultLayer, env::EnvLayer, file::FileLayer};
 
 mod cli;
+mod default;
 mod env;
 mod file;

--- a/server/args/src/lib.rs
+++ b/server/args/src/lib.rs
@@ -1,5 +1,5 @@
 pub use {
-    layers::{CliLayer, EnvLayer, FileLayer},
+    layers::{CliLayer, DefaultLayer, EnvLayer, FileLayer},
     stack::{ConfigBuilder, Layer},
 };
 


### PR DESCRIPTION
### Description
Adds a `Layer` that returns default config values that can be used as a base layer.

### Changes
- Add `DefaultLayer`

### Testing
:green_circle: CI

### Notes
#45 