### PR TITLE
Fix(sdk): Remove bytecode version restriction

### DIFF
--- a/sdk/hardhat-umi/package.json
+++ b/sdk/hardhat-umi/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@umi/hardhat-plugin",
-  "version": "0.1.0",
+  "name": "@moved/hardhat-plugin",
+  "version": "0.1.1",
   "description": "A plugin for Hardhat to support the development of Move smart contracts on the Umi Network.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -31,7 +31,7 @@
     "typescript": "5.8.2"
   },
   "peerDependencies": {
-    "hardhat": "2.22.19"
+    "hardhat": "2"
   },
   "repository": {
     "type": "git",

--- a/sdk/hardhat-umi/src/index.ts
+++ b/sdk/hardhat-umi/src/index.ts
@@ -170,7 +170,7 @@ async function movePackageBuild(moveType: MoveType, movePath: string, packagePat
     // Aptos and Sui uses different subcommands to build a package
     // Use the default bytecode version 6 for Aptos repo tag `aptos-node-v1.14.0`
     const cmd = moveType === MoveType.Aptos
-        ? `${movePath} move compile --package-dir ${packagePath} --skip-fetch-latest-git-deps --bytecode-version 6`
+        ? `${movePath} move compile --package-dir ${packagePath} --skip-fetch-latest-git-deps`
         : `${movePath} move build --path ${packagePath} --force --skip-fetch-latest-git-deps`;
 
     const [e, stdout, stderr] = await executeChildProcess(cmd);


### PR DESCRIPTION
### Description
Compiling with the bytecode version is not needed after upgrading the MoveVM.
The NPM package is already upgraded with this change.

### Changes
- Remove bytecode version restriction from the SDK.
- Relax `hardhat` peer dependency to major version 2 instead of specific minor version.
- Renamed the package back to `@moved/hardhat-plugin` cause that's how it is used in NPM package. We will update this after we are able to rename the NPM org name.

### Testing
Tested with an sample contract. The test case is explained in our [docs](https://docs.uminetwork.com/deploy-contract).