### PR TITLE
Fix(integration): Write L1 geth logs to a file

### DIFF
--- a/server/src/tests/integration.rs
+++ b/server/src/tests/integration.rs
@@ -251,6 +251,7 @@ fn generate_jwt() -> Result<()> {
 }
 
 async fn start_geth() -> Result<Child> {
+    let geth_logs = File::create("geth.log").unwrap();
     let geth_process = Command::new("geth")
         .current_dir("src/tests/optimism/")
         .args([
@@ -270,6 +271,7 @@ async fn start_geth() -> Result<Child> {
             "--http.api",
             "web3,debug,eth,txpool,net,engine",
         ])
+        .stderr(geth_logs)
         .spawn()?;
     // Give a second to settle geth
     pause(Some(Duration::from_secs(GETH_START_IN_SECS)));


### PR DESCRIPTION
### Description
Keep L1 logs in a file too, just like the others. This leaves no log messages on terminal to watch for println statements.

### Changes
- Write `geth` logs to a file