### PR TITLE
feat(server): Build server arguments from a stack of `Layer`s of configuration sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12492,6 +12492,7 @@ dependencies = [
  "umi-execution",
  "umi-genesis",
  "umi-genesis-image",
+ "umi-server-args",
  "umi-shared",
  "umi-state",
  "umi-storage-heed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ umi-evm-ext = { path = "evm-ext" }
 umi-execution = { path = "execution" }
 umi-genesis = { path = "genesis" }
 umi-genesis-image = { path = "genesis-image" }
+umi-server-args = { path = "server/args" }
 umi-shared = { path = "shared" }
 umi-state = { path = "state" }
 umi-storage-rocksdb = { path = "storage/rocksdb" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -34,6 +34,7 @@ umi-storage-heed.optional = true
 umi-storage-heed.workspace = true
 umi-storage-rocksdb.optional = true
 umi-storage-rocksdb.workspace = true
+umi-server-args.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/server/args/src/declaration.rs
+++ b/server/args/src/declaration.rs
@@ -9,6 +9,7 @@ use {
 pub struct Config {
     pub auth: AuthSocket,
     pub http: HttpSocket,
+    pub max_buffered_commands: u32,
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -28,6 +29,8 @@ pub struct OptionalConfig {
     pub auth: Option<OptionalAuthSocket>,
     #[command(flatten)]
     pub http: Option<OptionalHttpSocket>,
+    #[arg(long)]
+    pub max_buffered_commands: Option<u32>,
 }
 
 #[derive(Deserialize, Args, PartialEq, Debug, Clone, Default)]
@@ -55,6 +58,9 @@ impl TryFrom<OptionalConfig> for Config {
         Ok(Self {
             auth: value.auth.ok_or(MissingField("auth"))?.try_into()?,
             http: value.http.ok_or(MissingField("http"))?.try_into()?,
+            max_buffered_commands: value
+                .max_buffered_commands
+                .ok_or(MissingField("max_buffered_commands"))?,
         })
     }
 }
@@ -90,6 +96,7 @@ impl OptionalConfig {
             (Some(ours), Some(theirs)) => Some(ours.apply(theirs)),
             (ours, theirs) => theirs.or(ours),
         };
+        self.max_buffered_commands = other.max_buffered_commands.or(self.max_buffered_commands);
         self
     }
 }

--- a/server/args/src/layers/cli.rs
+++ b/server/args/src/layers/cli.rs
@@ -51,6 +51,7 @@ mod tests {
             http: Some(OptionalHttpSocket {
                 addr: "0.0.0.0:1".parse().ok(),
             }),
+            ..Default::default()
         };
 
         assert_eq!(actual_config, expected_config);

--- a/server/args/src/layers/default.rs
+++ b/server/args/src/layers/default.rs
@@ -37,6 +37,7 @@ mod tests {
             http: Some(OptionalHttpSocket {
                 addr: "0.0.0.0:1".parse().ok(),
             }),
+            ..Default::default()
         };
         let layer = DefaultLayer(expected_config.clone());
         let actual_config = layer.try_load().unwrap();

--- a/server/args/src/layers/env.rs
+++ b/server/args/src/layers/env.rs
@@ -43,6 +43,7 @@ mod tests {
             http: Some(OptionalHttpSocket {
                 addr: "0.0.0.0:1".parse().ok(),
             }),
+            ..Default::default()
         };
 
         assert_eq!(actual_config, expected_config);

--- a/server/args/src/lib.rs
+++ b/server/args/src/lib.rs
@@ -1,4 +1,5 @@
 pub use {
+    declaration::*,
     layers::{CliLayer, DefaultLayer, EnvLayer, FileLayer},
     stack::{ConfigBuilder, Layer},
 };

--- a/server/args/src/stack.rs
+++ b/server/args/src/stack.rs
@@ -101,12 +101,14 @@ mod tests {
                 http: Some(OptionalHttpSocket {
                     addr: Some(overridden_http_addr),
                 }),
+                max_buffered_commands: Some(1),
             }))
             .layer(StubLayer(OptionalConfig {
                 auth: None,
                 http: Some(OptionalHttpSocket {
                     addr: Some(http_addr),
                 }),
+                max_buffered_commands: Some(10),
             }))
             .try_build()
             .unwrap();
@@ -116,6 +118,7 @@ mod tests {
                 jwt_secret: String::new(),
             },
             http: HttpSocket { addr: http_addr },
+            max_buffered_commands: 10,
         };
 
         assert_eq!(actual_config, expected_config);

--- a/server/args/src/tests.rs
+++ b/server/args/src/tests.rs
@@ -21,6 +21,7 @@ fn test_config_parses_from_toml_successfully() {
         http: Some(OptionalHttpSocket {
             addr: Some("127.0.0.1:445".parse().unwrap()),
         }),
+        ..Default::default()
     };
 
     assert_eq!(actual_config, expected_config);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,7 +1,17 @@
+use {
+    umi_server::DEFAULTS,
+    umi_server_args::{CliLayer, ConfigBuilder, EnvLayer, FileLayer},
+};
+
 #[tokio::main]
 async fn main() {
-    // TODO: think about channel size bound
-    let max_buffered_commands = 1_000;
+    let args = ConfigBuilder::new()
+        .layer(DEFAULTS)
+        .layer(FileLayer::toml())
+        .layer(EnvLayer::new())
+        .layer(CliLayer::new())
+        .try_build()
+        .unwrap();
 
-    umi_server::run(max_buffered_commands).await;
+    umi_server::run(args).await;
 }


### PR DESCRIPTION
### Description
Constructs a config stack and uses it to run the server.

### Changes
- Add `umi-server-args` as a dependency of `umi-server`
- Use `ConfigBuilder` to build `Config` using a stack of `Layer`s

### Testing
:green_circle: CI

### Notes
#45