### PR TITLE
feat(server): Read JWT from `Config` of `server-args` crate

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       context: ./
       dockerfile: ./docker/Dockerfile.op-move
     environment:
-      JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
+      OP_MOVE_AUTH_JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
       OP_GETH_ADDR: "op-geth"
       PURGE: ${PURGE:-0}
     networks:

--- a/server/src/tests/integration.rs
+++ b/server/src/tests/integration.rs
@@ -20,7 +20,7 @@ use {
     openssl::rand::rand_bytes,
     serde_json::Value,
     std::{
-        env::{set_var, var},
+        env::var,
         fs::File,
         io::{prelude::*, Read},
         process::{Child, Command, Output},
@@ -259,10 +259,7 @@ fn generate_jwt() -> Result<String> {
     rand_bytes(&mut jwt).unwrap();
     let mut f = File::create("src/tests/optimism/packages/contracts-bedrock/deployments/jwt.txt")?;
     f.write_all(hex::encode(jwt).as_bytes())?;
-    // Set the env var to read the same secret key from the op-move main method
-    let jwt_secret = hex::encode(jwt);
-    set_var("JWT_SECRET", &jwt_secret);
-    Ok(jwt_secret)
+    Ok(hex::encode(jwt))
 }
 
 async fn start_geth() -> Result<Child> {


### PR DESCRIPTION
### Description
Adds a filter with optional secret into the routes, taking the jwt_secret using the `Config` of `server-args` crate.

### Changes
- Propagate `jwt_secret` from `Config` into `validate_jwt` filter

### Testing
:green_circle: CI
:green_circle: Docker

### Notes
#45 