### PR TITLE
fix(server): Resolve misplaced types in `rocksdb` dependencies

### DIFF
--- a/server/src/dependency/in_memory.rs
+++ b/server/src/dependency/in_memory.rs
@@ -1,7 +1,7 @@
 use {
     crate::dependency::shared::*,
     std::sync::Arc,
-    umi_app::{Application, ApplicationReader, CommandActor, SharedBlockHashCache},
+    umi_app::{Application, CommandActor, SharedBlockHashCache},
     umi_genesis::config::GenesisConfig,
 };
 


### PR DESCRIPTION
### Description
Fixes build error with `storage-rocksdb` feature flag on while `storage-lmdb` flag is off.

### Changes
- Use proper types for `rocksdb` dependencies

### Testing
:green_circle: `cargo clippy --features storage-rocksdb --all-targets`
:green_circle: `cargo clippy --features storage-lmdb --all-targets`
:green_circle: `cargo clippy --all-targets`
