### PR TITLE
fix(server): Remove database access from dependencies for `ApplicationReader`

### DIFF
--- a/server/src/dependency/heed.rs
+++ b/server/src/dependency/heed.rs
@@ -259,11 +259,8 @@ lazy_static::lazy_static! {
     };
 }
 
-pub static BLOCK_HASH_CACHE: LazyLock<SharedBlockHashCache> = LazyLock::new(|| {
-    let queries = Box::leak(Box::new(block::HeedBlockQueries::new()));
-    let db_ref = Box::leak(Box::new(db()));
-    SharedBlockHashCache::initialize_from_storage(db_ref, queries)
-});
+pub static BLOCK_HASH_CACHE: LazyLock<SharedBlockHashCache> =
+    LazyLock::new(SharedBlockHashCache::new);
 
 pub static HYBRID_BLOCK_HASH_CACHE: LazyLock<
     SharedHybridBlockHashCache<
@@ -274,7 +271,7 @@ pub static HYBRID_BLOCK_HASH_CACHE: LazyLock<
 > = LazyLock::new(|| {
     let queries = Box::leak(Box::new(block::HeedBlockQueries::new()));
     let db_ref = Box::leak(Box::new(db()));
-    SharedHybridBlockHashCache::initialize_from_storage(db_ref, queries)
+    SharedHybridBlockHashCache::new(db_ref, queries)
 });
 
 fn db() -> &'static umi_storage_heed::Env {

--- a/server/src/dependency/rocksdb.rs
+++ b/server/src/dependency/rocksdb.rs
@@ -261,13 +261,8 @@ lazy_static::lazy_static! {
     };
 }
 
-pub static BLOCK_HASH_CACHE: LazyLock<SharedBlockHashCache> = LazyLock::new(|| {
-    let queries = Box::leak(Box::new(
-        umi_storage_rocksdb::block::RocksDbBlockQueries::new(),
-    ));
-    let db_ref = Box::leak(Box::new(db()));
-    SharedBlockHashCache::initialize_from_storage(db_ref, queries)
-});
+pub static BLOCK_HASH_CACHE: LazyLock<SharedBlockHashCache> =
+    LazyLock::new(SharedBlockHashCache::new);
 
 pub static HYBRID_BLOCK_HASH_CACHE: LazyLock<
     umi_app::SharedHybridBlockHashCache<
@@ -280,7 +275,7 @@ pub static HYBRID_BLOCK_HASH_CACHE: LazyLock<
         umi_storage_rocksdb::block::RocksDbBlockQueries::new(),
     ));
     let db_ref = Box::leak(Box::new(db()));
-    umi_app::SharedHybridBlockHashCache::initialize_from_storage(db_ref, queries)
+    umi_app::SharedHybridBlockHashCache::new(db_ref, queries)
 });
 
 fn db() -> &'static umi_storage_rocksdb::RocksDb {


### PR DESCRIPTION
### Description
The server currently relies on `ApplicationReader` being stateless, i.e. not reading database to be initialized.

Not upholding this invariant breaks deployment.

This invariant was broken by the `BlockHashCache` that prefills itself on initialization.

This change makes it so that it is initialized empty.

### Changes
- Make `initialize_*` functions return result instead of panicking.
- Add `new` functions to `BlockHash` structs that initialize them empty.

### Testing
:green_circle: Clippy

### Notes
Might be worth looking into making the initialize step lazy initialized.