### PR TITLE
fix: Remove static database references

### DIFF
--- a/api/src/methods/block_number.rs
+++ b/api/src/methods/block_number.rs
@@ -3,9 +3,9 @@ use {
     umi_app::{ApplicationReader, Dependencies},
 };
 
-pub async fn execute(
+pub async fn execute<'app>(
     request: serde_json::Value,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'app, impl Dependencies<'app>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     parse_params_0(request)?;
     // this is a generic server error code
@@ -40,8 +40,8 @@ mod tests {
     };
 
     pub fn create_app_without_genesis() -> (
-        ApplicationReader<TestDependencies>,
-        Application<TestDependencies>,
+        ApplicationReader<'static, TestDependencies>,
+        Application<'static, TestDependencies>,
     ) {
         let genesis_config = GenesisConfig::default();
         let block_hash_cache = SharedBlockHashCache::default();

--- a/api/src/methods/call.rs
+++ b/api/src/methods/call.rs
@@ -74,7 +74,7 @@ mod tests {
     async fn test_execute_call_entry_fn(block: &str) {
         let (reader, mut app) = create_app();
         let (state_channel, rx) = mpsc::channel(10);
-        let state_actor = CommandActor::new(rx, app);
+        let state_actor = CommandActor::new(rx, &mut app);
 
         umi_app::run_with_actor(state_actor, async move {
             // Add funds to the account to deploy the `counter` contract
@@ -125,7 +125,7 @@ mod tests {
     async fn test_execute_call_script(block: &str) {
         let (reader, mut app) = create_app();
         let (state_channel, rx) = mpsc::channel(10);
-        let state_actor = CommandActor::new(rx, app);
+        let state_actor = CommandActor::new(rx, &mut app);
 
         umi_app::run_with_actor(state_actor, async move {
             // Add funds to the account to deploy the `counter` contract

--- a/api/src/methods/call.rs
+++ b/api/src/methods/call.rs
@@ -3,9 +3,9 @@ use {
     umi_app::{ApplicationReader, Dependencies},
 };
 
-pub async fn execute(
+pub async fn execute<'reader>(
     request: serde_json::Value,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let (transaction, block_number) = parse_params_2(request)?;
 
@@ -74,7 +74,7 @@ mod tests {
     async fn test_execute_call_entry_fn(block: &str) {
         let (reader, mut app) = create_app();
         let (state_channel, rx) = mpsc::channel(10);
-        let state_actor = CommandActor::new(rx, &mut app);
+        let state_actor = CommandActor::new(rx, app);
 
         umi_app::run_with_actor(state_actor, async move {
             // Add funds to the account to deploy the `counter` contract
@@ -125,7 +125,7 @@ mod tests {
     async fn test_execute_call_script(block: &str) {
         let (reader, mut app) = create_app();
         let (state_channel, rx) = mpsc::channel(10);
-        let state_actor = CommandActor::new(rx, &mut app);
+        let state_actor = CommandActor::new(rx, app);
 
         umi_app::run_with_actor(state_actor, async move {
             // Add funds to the account to deploy the `counter` contract

--- a/api/src/methods/chain_id.rs
+++ b/api/src/methods/chain_id.rs
@@ -3,8 +3,8 @@ use {
     umi_app::{ApplicationReader, Dependencies},
 };
 
-pub async fn execute(
-    app: &ApplicationReader<impl Dependencies>,
+pub async fn execute<'reader>(
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let response = app.chain_id();
     Ok(serde_json::to_value(format!("{response:#x}"))

--- a/api/src/methods/estimate_gas.rs
+++ b/api/src/methods/estimate_gas.rs
@@ -6,9 +6,9 @@ use {
 
 const BASE_FEE: u64 = 21_000;
 
-pub async fn execute(
+pub async fn execute<'reader>(
     request: serde_json::Value,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let (transaction, block_number) = parse_params(request)?;
     let response = std::cmp::max(app.estimate_gas(transaction, block_number)?, BASE_FEE);
@@ -104,7 +104,7 @@ mod tests {
     async fn test_execute(block: &str) {
         let (state_channel, rx) = mpsc::channel(10);
         let (reader, mut app) = create_app();
-        let state_actor = CommandActor::new(rx, &mut app);
+        let state_actor = CommandActor::new(rx, app);
 
         umi_app::run_with_actor(state_actor, async move {
             deposit_eth("0x8fd379246834eac74b8419ffda202cf8051f7a03", &state_channel).await;

--- a/api/src/methods/estimate_gas.rs
+++ b/api/src/methods/estimate_gas.rs
@@ -104,7 +104,7 @@ mod tests {
     async fn test_execute(block: &str) {
         let (state_channel, rx) = mpsc::channel(10);
         let (reader, mut app) = create_app();
-        let state_actor = CommandActor::new(rx, app);
+        let state_actor = CommandActor::new(rx, &mut app);
 
         umi_app::run_with_actor(state_actor, async move {
             deposit_eth("0x8fd379246834eac74b8419ffda202cf8051f7a03", &state_channel).await;

--- a/api/src/methods/fee_history.rs
+++ b/api/src/methods/fee_history.rs
@@ -7,9 +7,9 @@ use {
     umi_app::{ApplicationReader, Dependencies},
 };
 
-pub async fn execute(
+pub async fn execute<'reader>(
     request: serde_json::Value,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let (block_count, block_number, reward_percentiles) = parse_params(request)?;
 

--- a/api/src/methods/get_balance.rs
+++ b/api/src/methods/get_balance.rs
@@ -3,9 +3,9 @@ use {
     umi_app::{ApplicationReader, Dependencies},
 };
 
-pub async fn execute(
+pub async fn execute<'reader>(
     request: serde_json::Value,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let (address, block_number) = parse_params_2(request)?;
 

--- a/api/src/methods/get_block_by_hash.rs
+++ b/api/src/methods/get_block_by_hash.rs
@@ -3,9 +3,9 @@ use {
     umi_app::{ApplicationReader, Dependencies},
 };
 
-pub async fn execute(
+pub async fn execute<'reader>(
     request: serde_json::Value,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let (block_hash, include_transactions) = parse_params_2(request)?;
 

--- a/api/src/methods/get_block_by_number.rs
+++ b/api/src/methods/get_block_by_number.rs
@@ -3,9 +3,9 @@ use {
     umi_app::{ApplicationReader, Dependencies},
 };
 
-pub async fn execute(
+pub async fn execute<'reader>(
     request: serde_json::Value,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let (number, include_transactions) = parse_params_2(request)?;
 
@@ -100,7 +100,7 @@ mod tests {
     async fn test_latest_block_height_is_updated_with_newly_built_block() {
         let (state_channel, rx) = mpsc::channel(10);
         let (reader, mut app) = create_app();
-        let state: CommandActor<TestDependencies> = CommandActor::new(rx, &mut app);
+        let state: CommandActor<TestDependencies> = CommandActor::new(rx, app);
 
         umi_app::run_with_actor(state, async move {
             let request = example_request(Latest);
@@ -133,7 +133,7 @@ mod tests {
     async fn test_latest_block_height_is_same_as_tag(tag: BlockNumberOrTag) {
         let (state_channel, rx) = mpsc::channel(10);
         let (reader, mut app) = create_app();
-        let state: CommandActor<TestDependencies> = CommandActor::new(rx, &mut app);
+        let state: CommandActor<TestDependencies> = CommandActor::new(rx, app);
 
         umi_app::run_with_actor(state, async move {
             let msg = Command::StartBlockBuild {

--- a/api/src/methods/get_block_by_number.rs
+++ b/api/src/methods/get_block_by_number.rs
@@ -100,7 +100,7 @@ mod tests {
     async fn test_latest_block_height_is_updated_with_newly_built_block() {
         let (state_channel, rx) = mpsc::channel(10);
         let (reader, mut app) = create_app();
-        let state: CommandActor<TestDependencies> = CommandActor::new(rx, app);
+        let state: CommandActor<TestDependencies> = CommandActor::new(rx, &mut app);
 
         umi_app::run_with_actor(state, async move {
             let request = example_request(Latest);
@@ -133,7 +133,7 @@ mod tests {
     async fn test_latest_block_height_is_same_as_tag(tag: BlockNumberOrTag) {
         let (state_channel, rx) = mpsc::channel(10);
         let (reader, mut app) = create_app();
-        let state: CommandActor<TestDependencies> = CommandActor::new(rx, app);
+        let state: CommandActor<TestDependencies> = CommandActor::new(rx, &mut app);
 
         umi_app::run_with_actor(state, async move {
             let msg = Command::StartBlockBuild {

--- a/api/src/methods/get_nonce.rs
+++ b/api/src/methods/get_nonce.rs
@@ -4,9 +4,9 @@ use {
     umi_app::{ApplicationReader, Dependencies},
 };
 
-pub async fn execute(
+pub async fn execute<'reader>(
     request: serde_json::Value,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let (address, block_number) = parse_params(request)?;
 

--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -7,9 +7,9 @@ use {
     umi_app::{ApplicationReader, Dependencies},
 };
 
-pub async fn execute_v3(
+pub async fn execute_v3<'reader>(
     request: serde_json::Value,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let payload_id: PayloadId = parse_params_1(request)?;
 
@@ -169,7 +169,7 @@ mod tests {
             payload_queries: InMemoryPayloadQueries::new(),
             evm_storage,
         };
-        let (queue, state) = umi_app::create(&mut app, 10);
+        let (queue, state) = umi_app::create(app, 10);
 
         umi_app::run_with_actor(state, async move {
             // Update the state with an execution payload

--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -169,7 +169,7 @@ mod tests {
             payload_queries: InMemoryPayloadQueries::new(),
             evm_storage,
         };
-        let (queue, state) = umi_app::create(app, 10);
+        let (queue, state) = umi_app::create(&mut app, 10);
 
         umi_app::run_with_actor(state, async move {
             // Update the state with an execution payload

--- a/api/src/methods/get_proof.rs
+++ b/api/src/methods/get_proof.rs
@@ -10,9 +10,9 @@ use {
     umi_app::{ApplicationReader, Dependencies},
 };
 
-pub async fn execute(
+pub async fn execute<'reader>(
     request: serde_json::Value,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let (address, storage_slots, block_number) = parse_params(request)?;
 

--- a/api/src/methods/get_transaction_by_hash.rs
+++ b/api/src/methods/get_transaction_by_hash.rs
@@ -51,7 +51,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute() {
         let (reader, mut app) = create_app();
-        let (queue, state) = umi_app::create(app, 10);
+        let (queue, state) = umi_app::create(&mut app, 10);
 
         umi_app::run_with_actor(state, async move {
             // 1. Send transaction

--- a/api/src/methods/get_transaction_by_hash.rs
+++ b/api/src/methods/get_transaction_by_hash.rs
@@ -3,9 +3,9 @@ use {
     umi_app::{ApplicationReader, Dependencies},
 };
 
-pub async fn execute(
+pub async fn execute<'reader>(
     request: serde_json::Value,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let tx_hash = parse_params_1(request)?;
 
@@ -51,7 +51,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute() {
         let (reader, mut app) = create_app();
-        let (queue, state) = umi_app::create(&mut app, 10);
+        let (queue, state) = umi_app::create(app, 10);
 
         umi_app::run_with_actor(state, async move {
             // 1. Send transaction

--- a/api/src/methods/get_transaction_receipt.rs
+++ b/api/src/methods/get_transaction_receipt.rs
@@ -3,9 +3,9 @@ use {
     umi_app::{ApplicationReader, Dependencies},
 };
 
-pub async fn execute(
+pub async fn execute<'reader>(
     request: serde_json::Value,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let tx_hash = parse_params_1(request)?;
 
@@ -49,7 +49,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute() {
         let (reader, mut app) = create_app();
-        let (queue, state) = umi_app::create(&mut app, 10);
+        let (queue, state) = umi_app::create(app, 10);
 
         umi_app::run_with_actor(state, async move {
             // 1. Send transaction

--- a/api/src/methods/get_transaction_receipt.rs
+++ b/api/src/methods/get_transaction_receipt.rs
@@ -49,7 +49,7 @@ mod tests {
     #[tokio::test]
     async fn test_execute() {
         let (reader, mut app) = create_app();
-        let (queue, state) = umi_app::create(app, 10);
+        let (queue, state) = umi_app::create(&mut app, 10);
 
         umi_app::run_with_actor(state, async move {
             // 1. Send transaction

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -57,8 +57,8 @@ pub mod tests {
     pub const PRIVATE_KEY: [u8; 32] = [0xaa; 32];
 
     pub fn create_app() -> (
-        ApplicationReader<TestDependencies>,
-        Application<TestDependencies>,
+        ApplicationReader<'static, TestDependencies>,
+        Application<'static, TestDependencies>,
     ) {
         let genesis_config = GenesisConfig::default();
         let mut block_hash_cache = SharedBlockHashCache::default();
@@ -210,8 +210,8 @@ pub mod tests {
         address: AccountAddress,
         height: u64,
     ) -> Box<(
-        ApplicationReader<impl DependenciesThreadSafe<State = InMemoryState>>,
-        Application<impl DependenciesThreadSafe<State = InMemoryState>>,
+        ApplicationReader<'static, impl DependenciesThreadSafe<'static, State = InMemoryState>>,
+        Application<'static, impl DependenciesThreadSafe<'static, State = InMemoryState>>,
     )> {
         #[derive(Debug, Clone)]
         struct StubLatest(u64);

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -350,7 +350,7 @@ mod tests {
             payload_queries: InMemoryPayloadQueries::new(),
             evm_storage,
         };
-        let (queue, state) = umi_app::create(app, 10);
+        let (queue, state) = umi_app::create(&mut app, 10);
 
         umi_app::run_with_actor(state, async move {
             let fc_updated_request: serde_json::Value = serde_json::from_str(

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -8,9 +8,9 @@ use {
     umi_shared::primitives::B256,
 };
 
-pub async fn execute_v3(
+pub async fn execute_v3<'reader>(
     request: serde_json::Value,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     let (execution_payload, expected_blob_versioned_hashes, parent_beacon_block_root) =
         parse_params_3(request)?;
@@ -24,11 +24,11 @@ pub async fn execute_v3(
     Ok(serde_json::to_value(response).expect("Must be able to JSON-serialize response"))
 }
 
-async fn inner_execute_v3(
+async fn inner_execute_v3<'reader>(
     execution_payload: ExecutionPayloadV3,
     expected_blob_versioned_hashes: Vec<B256>,
     parent_beacon_block_root: B256,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<PayloadStatusV1, JsonRpcError> {
     // Spec: https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#specification
 
@@ -350,7 +350,7 @@ mod tests {
             payload_queries: InMemoryPayloadQueries::new(),
             evm_storage,
         };
-        let (queue, state) = umi_app::create(&mut app, 10);
+        let (queue, state) = umi_app::create(app, 10);
 
         umi_app::run_with_actor(state, async move {
             let fc_updated_request: serde_json::Value = serde_json::from_str(

--- a/api/src/methods/send_raw_transaction.rs
+++ b/api/src/methods/send_raw_transaction.rs
@@ -61,7 +61,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_execute() {
         let (_reader, mut app) = create_app();
-        let (queue, state) = umi_app::create(&mut app, 10);
+        let (queue, state) = umi_app::create(app, 10);
 
         umi_app::run_with_actor(state, async move {
             let request = example_request();

--- a/api/src/methods/send_raw_transaction.rs
+++ b/api/src/methods/send_raw_transaction.rs
@@ -61,7 +61,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_execute() {
         let (_reader, mut app) = create_app();
-        let (queue, state) = umi_app::create(app, 10);
+        let (queue, state) = umi_app::create(&mut app, 10);
 
         umi_app::run_with_actor(state, async move {
             let request = example_request();

--- a/api/src/request.rs
+++ b/api/src/request.rs
@@ -8,12 +8,12 @@ use {
     umi_blockchain::payload::NewPayloadId,
 };
 
-pub async fn handle(
+pub async fn handle<'reader>(
     request: serde_json::Value,
     queue: CommandQueue,
     is_allowed: impl Fn(&MethodName) -> bool,
     payload_id: &impl NewPayloadId,
-    app: ApplicationReader<impl Dependencies>,
+    app: ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> JsonRpcResponse {
     let id = json_utils::get_field(&request, "id");
     let jsonrpc = json_utils::get_field(&request, "jsonrpc");
@@ -34,12 +34,12 @@ pub async fn handle(
     }
 }
 
-async fn inner_handle_request(
+async fn inner_handle_request<'reader>(
     request: serde_json::Value,
     queue: CommandQueue,
     is_allowed: impl Fn(&MethodName) -> bool,
     payload_id: &impl NewPayloadId,
-    app: &ApplicationReader<impl Dependencies>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     use {crate::methods::*, MethodName::*};
 

--- a/app/src/block_hash.rs
+++ b/app/src/block_hash.rs
@@ -398,7 +398,7 @@ mod tests {
     #[test]
     fn test_hybrid_cache_ring_buffer_hit() {
         let mut cache =
-            HybridBlockHashCache::try_from_storage(&MockStorage, &MockBlockQueries).unwrap();
+            HybridBlockHashCache::try_from_storage(MockStorage, &MockBlockQueries).unwrap();
 
         let hash = B256::from([42u8; 32]);
         cache.push(100, hash);
@@ -408,8 +408,7 @@ mod tests {
 
     #[test]
     fn test_hybrid_cache_storage_fallback() {
-        let cache =
-            HybridBlockHashCache::try_from_storage(&MockStorage, &MockBlockQueries).unwrap();
+        let cache = HybridBlockHashCache::try_from_storage(MockStorage, &MockBlockQueries).unwrap();
 
         // Should fall back to storage for block 1500
         let expected_hash = B256::from([((1500 % 256) as u8); 32]);
@@ -418,8 +417,7 @@ mod tests {
 
     #[test]
     fn test_hybrid_cache_storage_miss() {
-        let cache =
-            HybridBlockHashCache::try_from_storage(&MockStorage, &MockBlockQueries).unwrap();
+        let cache = HybridBlockHashCache::try_from_storage(MockStorage, &MockBlockQueries).unwrap();
 
         // Should return None for blocks not in ring buffer or storage
         assert_eq!(cache.hash_by_number(500), None);
@@ -428,7 +426,7 @@ mod tests {
     #[test]
     fn test_hybrid_cache_priority() {
         let mut cache =
-            HybridBlockHashCache::try_from_storage(&MockStorage, &MockBlockQueries).unwrap();
+            HybridBlockHashCache::try_from_storage(MockStorage, &MockBlockQueries).unwrap();
 
         // Add block 1500 to ring buffer with different hash than storage would return
         let ring_buffer_hash = B256::from([99u8; 32]);

--- a/app/src/block_hash.rs
+++ b/app/src/block_hash.rs
@@ -165,17 +165,17 @@ impl BlockHashWriter for SharedBlockHashCache {
 }
 
 #[derive(Debug, Clone)]
-pub struct HybridBlockHashCache<'a, S, B> {
+pub struct HybridBlockHashCache<S, B> {
     ring_buffer: BlockHashRingBuffer,
-    storage: &'a S,
-    block_query: &'a B,
+    storage: S,
+    block_query: B,
 }
 
-impl<'a, S, B> HybridBlockHashCache<'a, S, B>
+impl<S, B> HybridBlockHashCache<S, B>
 where
     B: BlockQueries<Storage = S>,
 {
-    pub const fn new(storage: &'a S, block_query: &'a B) -> Self {
+    pub const fn new(storage: S, block_query: B) -> Self {
         Self {
             ring_buffer: BlockHashRingBuffer::new(),
             storage,
@@ -183,8 +183,8 @@ where
         }
     }
 
-    pub fn try_from_storage(storage: &'a S, block_query: &'a B) -> Result<Self, B::Err> {
-        let ring_buffer = BlockHashRingBuffer::try_from_storage(storage, block_query)?;
+    pub fn try_from_storage(storage: S, block_query: B) -> Result<Self, B::Err> {
+        let ring_buffer = BlockHashRingBuffer::try_from_storage(&storage, &block_query)?;
 
         Ok(Self {
             ring_buffer,
@@ -194,7 +194,7 @@ where
     }
 }
 
-impl<S, B> BlockHashLookup for HybridBlockHashCache<'_, S, B>
+impl<S, B> BlockHashLookup for HybridBlockHashCache<S, B>
 where
     B: BlockQueries<Storage = S>,
 {
@@ -205,7 +205,7 @@ where
 
         if let Ok(Some(block)) = self
             .block_query
-            .by_height(self.storage, block_number, false)
+            .by_height(&self.storage, block_number, false)
         {
             Some(block.0.header.hash)
         } else {
@@ -214,7 +214,7 @@ where
     }
 }
 
-impl<S, B> BlockHashWriter for HybridBlockHashCache<'_, S, B>
+impl<S, B> BlockHashWriter for HybridBlockHashCache<S, B>
 where
     B: BlockQueries<Storage = S>,
 {
@@ -224,22 +224,22 @@ where
 }
 
 #[derive(Debug, Clone)]
-pub struct SharedHybridBlockHashCache<'a, S, B> {
-    inner: Arc<RwLock<HybridBlockHashCache<'a, S, B>>>,
+pub struct SharedHybridBlockHashCache<S, B> {
+    inner: Arc<RwLock<HybridBlockHashCache<S, B>>>,
 }
 
-impl<'a, S, B> SharedHybridBlockHashCache<'a, S, B>
+impl<S, B> SharedHybridBlockHashCache<S, B>
 where
     S: Clone,
     B: Clone + BlockQueries<Storage = S>,
 {
-    pub fn new(storage: &'a S, block_query: &'a B) -> Self {
+    pub fn new(storage: S, block_query: B) -> Self {
         Self {
             inner: Arc::new(RwLock::new(HybridBlockHashCache::new(storage, block_query))),
         }
     }
 
-    pub fn try_from_storage(storage: &'a S, block_query: &'a B) -> Result<Self, B::Err> {
+    pub fn try_from_storage(storage: S, block_query: B) -> Result<Self, B::Err> {
         let cache = HybridBlockHashCache::try_from_storage(storage, block_query)?;
 
         Ok(Self {
@@ -248,7 +248,7 @@ where
     }
 }
 
-impl<S, B> BlockHashLookup for SharedHybridBlockHashCache<'_, S, B>
+impl<S, B> BlockHashLookup for SharedHybridBlockHashCache<S, B>
 where
     S: Clone,
     B: Clone + BlockQueries<Storage = S>,
@@ -263,7 +263,7 @@ where
     }
 }
 
-impl<S, B> BlockHashWriter for SharedHybridBlockHashCache<'_, S, B>
+impl<S, B> BlockHashWriter for SharedHybridBlockHashCache<S, B>
 where
     S: Clone,
     B: Clone + BlockQueries<Storage = S>,

--- a/app/src/command.rs
+++ b/app/src/command.rs
@@ -33,7 +33,7 @@ use {
     umi_state::State,
 };
 
-impl<D: Dependencies> Application<D> {
+impl<'app, D: Dependencies<'app>> Application<'app, D> {
     pub fn start_block_build(&mut self, attributes: Payload, id: PayloadId) {
         if self
             .payload_queries

--- a/app/src/dependency.rs
+++ b/app/src/dependency.rs
@@ -7,7 +7,7 @@ use {
     umi_genesis::config::GenesisConfig, umi_shared::primitives::B256,
 };
 
-pub struct ApplicationReader<D: Dependencies> {
+pub struct ApplicationReader<'app, D: Dependencies<'app>> {
     pub genesis_config: GenesisConfig,
     pub base_token: D::BaseTokenAccounts,
     pub block_queries: D::BlockQueries,
@@ -21,9 +21,9 @@ pub struct ApplicationReader<D: Dependencies> {
     pub transaction_queries: D::TransactionQueries,
 }
 
-unsafe impl<D: Dependencies> Sync for ApplicationReader<D> {}
+unsafe impl<'app, D: Dependencies<'app>> Sync for ApplicationReader<'app, D> {}
 
-impl<D: Dependencies> Clone for ApplicationReader<D> {
+impl<'app, D: Dependencies<'app>> Clone for ApplicationReader<'app, D> {
     fn clone(&self) -> Self {
         Self {
             genesis_config: self.genesis_config.clone(),
@@ -41,7 +41,7 @@ impl<D: Dependencies> Clone for ApplicationReader<D> {
     }
 }
 
-impl<D: Dependencies> ApplicationReader<D> {
+impl<'app, D: Dependencies<'app>> ApplicationReader<'app, D> {
     pub fn new(deps: D, genesis_config: &GenesisConfig) -> Self {
         Self {
             genesis_config: genesis_config.clone(),
@@ -59,7 +59,7 @@ impl<D: Dependencies> ApplicationReader<D> {
     }
 }
 
-pub struct Application<D: Dependencies> {
+pub struct Application<'app, D: Dependencies<'app>> {
     pub genesis_config: GenesisConfig,
     pub mem_pool: Mempool,
     pub block_hash_writer: D::BlockHashWriter,
@@ -71,9 +71,9 @@ pub struct Application<D: Dependencies> {
     pub block_hash: D::BlockHash,
     pub block_queries: D::BlockQueries,
     pub block_repository: D::BlockRepository,
-    pub on_payload: &'static D::OnPayload,
-    pub on_tx: &'static D::OnTx,
-    pub on_tx_batch: &'static D::OnTxBatch,
+    pub on_payload: &'app D::OnPayload,
+    pub on_tx: &'app D::OnTx,
+    pub on_tx_batch: &'app D::OnTxBatch,
     pub payload_queries: D::PayloadQueries,
     pub receipt_queries: D::ReceiptQueries,
     pub receipt_repository: D::ReceiptRepository,
@@ -92,7 +92,7 @@ pub struct Application<D: Dependencies> {
     pub resolver_cache: ResolverCache,
 }
 
-impl<D: Dependencies> Application<D> {
+impl<'app, D: Dependencies<'app>> Application<'app, D> {
     pub fn new(mut deps: D, genesis_config: &GenesisConfig) -> Self {
         Self {
             genesis_config: genesis_config.clone(),
@@ -130,8 +130,9 @@ impl<D: Dependencies> Application<D> {
     }
 }
 
-pub trait DependenciesThreadSafe:
+pub trait DependenciesThreadSafe<'db>:
     Dependencies<
+        'db,
         BaseTokenAccounts: Send + 'static,
         BlockHash: Send + 'static,
         BlockHashLookup: Send + 'static,
@@ -162,7 +163,9 @@ pub trait DependenciesThreadSafe:
 }
 
 impl<
+    'app,
     T: Dependencies<
+            'app,
             BaseTokenAccounts: Send + 'static,
             BlockHash: Send + 'static,
             BlockHashLookup: Send + 'static,
@@ -189,11 +192,11 @@ impl<
             CreateL2GasFee: Send + 'static,
         > + Send
         + 'static,
-> DependenciesThreadSafe for T
+> DependenciesThreadSafe<'app> for T
 {
 }
 
-pub trait Dependencies {
+pub trait Dependencies<'db> {
     type BaseTokenAccounts: umi_execution::BaseTokenAccounts + Clone;
     type BlockHash: umi_blockchain::block::BlockHash;
     type BlockHashLookup: umi_evm_ext::state::BlockHashLookup + Clone;
@@ -203,13 +206,13 @@ pub trait Dependencies {
     type BlockRepository: umi_blockchain::block::BlockRepository<Storage = Self::SharedStorage>;
 
     /// A function invoked on an execution of a new payload.
-    type OnPayload: Fn(&mut Application<Self>, PayloadId, B256) + 'static + ?Sized;
+    type OnPayload: Fn(&mut Application<'db, Self>, PayloadId, B256) + 'db + ?Sized;
 
     /// A function invoked on an execution of a new transaction.
-    type OnTx: Fn(&mut Application<Self>, ChangeSet) + 'static + ?Sized;
+    type OnTx: Fn(&mut Application<'db, Self>, ChangeSet) + 'db + ?Sized;
 
     /// A function invoked on a completion of new transaction execution batch.
-    type OnTxBatch: Fn(&mut Application<Self>) + 'static + ?Sized;
+    type OnTxBatch: Fn(&mut Application<'db, Self>) + 'db + ?Sized;
 
     type PayloadQueries: umi_blockchain::payload::PayloadQueries<Storage = Self::SharedStorageReader>
         + Clone;
@@ -242,11 +245,11 @@ pub trait Dependencies {
 
     fn block_repository() -> Self::BlockRepository;
 
-    fn on_payload() -> &'static Self::OnPayload;
+    fn on_payload() -> &'db Self::OnPayload;
 
-    fn on_tx() -> &'static Self::OnTx;
+    fn on_tx() -> &'db Self::OnTx;
 
-    fn on_tx_batch() -> &'static Self::OnTxBatch;
+    fn on_tx_batch() -> &'db Self::OnTxBatch;
 
     fn payload_queries() -> Self::PayloadQueries;
 
@@ -336,6 +339,7 @@ mod test_doubles {
     );
 
     impl<
+        'app,
         SQ: StateQueries + Clone + Send + 'static,
         S: State + Send + 'static,
         BT: umi_execution::BaseTokenAccounts + Clone + Send + 'static,
@@ -357,7 +361,7 @@ mod test_doubles {
         BF: umi_blockchain::block::BaseGasFee + Send + 'static,
         F1: umi_execution::CreateL1GasFee + Send + 'static,
         F2: umi_execution::CreateL2GasFee + Send + 'static,
-    > Dependencies
+    > Dependencies<'app>
         for TestDependencies<
             SQ,
             S,
@@ -388,9 +392,9 @@ mod test_doubles {
         type BlockHashWriter = BHW;
         type BlockQueries = BQ;
         type BlockRepository = BR;
-        type OnPayload = crate::OnPayload<Application<Self>>;
-        type OnTx = crate::OnTx<Application<Self>>;
-        type OnTxBatch = crate::OnTxBatch<Application<Self>>;
+        type OnPayload = crate::OnPayload<Application<'app, Self>>;
+        type OnTx = crate::OnTx<Application<'app, Self>>;
+        type OnTxBatch = crate::OnTxBatch<Application<'app, Self>>;
         type PayloadQueries = PQ;
         type ReceiptQueries = RQ;
         type ReceiptRepository = RR;
@@ -431,15 +435,15 @@ mod test_doubles {
             unimplemented!("Dependencies are created manually in tests")
         }
 
-        fn on_payload() -> &'static Self::OnPayload {
+        fn on_payload() -> &'app Self::OnPayload {
             unimplemented!("Dependencies are created manually in tests")
         }
 
-        fn on_tx() -> &'static Self::OnTx {
+        fn on_tx() -> &'app Self::OnTx {
             unimplemented!("Dependencies are created manually in tests")
         }
 
-        fn on_tx_batch() -> &'static Self::OnTxBatch {
+        fn on_tx_batch() -> &'app Self::OnTxBatch {
             unimplemented!("Dependencies are created manually in tests")
         }
 

--- a/app/src/dependency.rs
+++ b/app/src/dependency.rs
@@ -48,7 +48,7 @@ impl<'app, D: Dependencies<'app>> ApplicationReader<'app, D> {
             base_token: D::base_token_accounts(genesis_config),
             block_hash_lookup: deps.block_hash_lookup(),
             block_queries: D::block_queries(),
-            payload_queries: D::payload_queries(),
+            payload_queries: deps.payload_queries(),
             receipt_queries: D::receipt_queries(),
             receipt_memory: deps.receipt_memory_reader(),
             storage: deps.shared_storage_reader(),
@@ -109,7 +109,7 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             on_payload: D::on_payload(),
             on_tx: D::on_tx(),
             on_tx_batch: D::on_tx_batch(),
-            payload_queries: D::payload_queries(),
+            payload_queries: deps.payload_queries(),
             receipt_queries: D::receipt_queries(),
             receipt_repository: D::receipt_repository(),
             receipt_memory: deps.receipt_memory(),
@@ -158,7 +158,7 @@ pub trait DependenciesThreadSafe<'db>:
         CreateL1GasFee: Send + 'static,
         CreateL2GasFee: Send + 'static,
     > + Send
-    + 'static
+    + 'db
 {
 }
 
@@ -191,7 +191,7 @@ impl<
             CreateL1GasFee: Send + 'static,
             CreateL2GasFee: Send + 'static,
         > + Send
-        + 'static,
+        + 'app,
 > DependenciesThreadSafe<'app> for T
 {
 }
@@ -251,7 +251,7 @@ pub trait Dependencies<'db> {
 
     fn on_tx_batch() -> &'db Self::OnTxBatch;
 
-    fn payload_queries() -> Self::PayloadQueries;
+    fn payload_queries(&self) -> Self::PayloadQueries;
 
     fn receipt_queries() -> Self::ReceiptQueries;
 
@@ -447,7 +447,7 @@ mod test_doubles {
             unimplemented!("Dependencies are created manually in tests")
         }
 
-        fn payload_queries() -> Self::PayloadQueries {
+        fn payload_queries(&self) -> Self::PayloadQueries {
             unimplemented!("Dependencies are created manually in tests")
         }
 

--- a/app/src/query.rs
+++ b/app/src/query.rs
@@ -30,7 +30,7 @@ enum BlockNumberOrHash {
     Hash(B256),
 }
 
-impl<D: Dependencies> ApplicationReader<D> {
+impl<'app, D: Dependencies<'app>> ApplicationReader<'app, D> {
     pub fn chain_id(&self) -> u64 {
         self.genesis_config.chain_id
     }

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -66,8 +66,8 @@ fn create_app_with_given_queries<SQ: StateQueries + Clone + Send + Sync + 'stati
     height: u64,
     state_queries: SQ,
 ) -> (
-    ApplicationReader<TestDependencies<SQ>>,
-    Application<TestDependencies<SQ>>,
+    ApplicationReader<'static, TestDependencies<SQ>>,
+    Application<'static, TestDependencies<SQ>>,
 ) {
     let genesis_config = GenesisConfig::default();
     let mut block_hash_cache = SharedBlockHashCache::default();
@@ -187,8 +187,8 @@ fn create_app_with_fake_queries(
     initial_balance: U256,
     height: u64,
 ) -> (
-    ApplicationReader<TestDependencies>,
-    Application<TestDependencies>,
+    ApplicationReader<'static, TestDependencies>,
+    Application<'static, TestDependencies>,
 ) {
     let genesis_config = GenesisConfig::default();
     let mut block_hash_cache = SharedBlockHashCache::default();

--- a/app/src/uninit.rs
+++ b/app/src/uninit.rs
@@ -12,16 +12,16 @@ use {
 /// A set of non-operational dependencies that can be used to satisfy a parameter list.
 pub struct Uninitialized;
 
-impl Dependencies for Uninitialized {
+impl<'app> Dependencies<'app> for Uninitialized {
     type BaseTokenAccounts = ();
     type BlockHash = B256;
     type BlockQueries = ();
     type BlockHashLookup = ();
     type BlockHashWriter = ();
     type BlockRepository = ();
-    type OnPayload = crate::OnPayload<Application<Self>>;
-    type OnTx = crate::OnTx<Application<Self>>;
-    type OnTxBatch = crate::OnTxBatch<Application<Self>>;
+    type OnPayload = crate::OnPayload<Application<'app, Self>>;
+    type OnTx = crate::OnTx<Application<'app, Self>>;
+    type OnTxBatch = crate::OnTxBatch<Application<'app, Self>>;
     type PayloadQueries = ();
     type ReceiptQueries = ();
     type ReceiptRepository = ();
@@ -52,15 +52,15 @@ impl Dependencies for Uninitialized {
 
     fn block_repository() -> Self::BlockRepository {}
 
-    fn on_payload() -> &'static Self::OnPayload {
+    fn on_payload() -> &'app Self::OnPayload {
         &|_, _, _| {}
     }
 
-    fn on_tx() -> &'static Self::OnTx {
+    fn on_tx() -> &'app Self::OnTx {
         &|_, _| {}
     }
 
-    fn on_tx_batch() -> &'static Self::OnTxBatch {
+    fn on_tx_batch() -> &'app Self::OnTxBatch {
         &|_| {}
     }
 

--- a/app/src/uninit.rs
+++ b/app/src/uninit.rs
@@ -64,7 +64,7 @@ impl<'app> Dependencies<'app> for Uninitialized {
         &|_| {}
     }
 
-    fn payload_queries() -> Self::PayloadQueries {}
+    fn payload_queries(&self) -> Self::PayloadQueries {}
 
     fn receipt_queries() -> Self::ReceiptQueries {}
 

--- a/blockchain/src/block/read.rs
+++ b/blockchain/src/block/read.rs
@@ -4,7 +4,6 @@ use {
     std::fmt::Debug,
     umi_shared::primitives::B256,
 };
-
 pub trait BlockQueries: Debug {
     /// The associated error type for the backing storage access operation.
     type Err: Debug;
@@ -26,6 +25,33 @@ pub trait BlockQueries: Debug {
     ) -> Result<Option<BlockResponse>, Self::Err>;
 
     fn latest(&self, storage: &Self::Storage) -> Result<Option<u64>, Self::Err>;
+}
+
+impl<T: BlockQueries> BlockQueries for &T {
+    type Err = T::Err;
+    type Storage = T::Storage;
+
+    fn by_hash(
+        &self,
+        storage: &Self::Storage,
+        hash: B256,
+        include_transactions: bool,
+    ) -> Result<Option<BlockResponse>, Self::Err> {
+        (*self).by_hash(storage, hash, include_transactions)
+    }
+
+    fn by_height(
+        &self,
+        storage: &Self::Storage,
+        height: u64,
+        include_transactions: bool,
+    ) -> Result<Option<BlockResponse>, Self::Err> {
+        (*self).by_height(storage, height, include_transactions)
+    }
+
+    fn latest(&self, storage: &Self::Storage) -> Result<Option<u64>, Self::Err> {
+        (*self).latest(storage)
+    }
 }
 
 type RpcBlock = alloy::rpc::types::Block<RpcTransaction>;

--- a/server/benches/perf/queue/tests.rs
+++ b/server/benches/perf/queue/tests.rs
@@ -11,10 +11,10 @@ use {
     umi_server::initialize_app,
 };
 
-fn build_1000_blocks(
+fn build_1000_blocks<'app>(
     runtime: &Runtime,
     bencher: &mut BenchmarkGroup<WallTime>,
-    app: &mut Application<impl DependenciesThreadSafe>,
+    app: &mut Application<'app, impl DependenciesThreadSafe<'app>>,
     buffer_size: u32,
 ) {
     bencher.throughput(Throughput::Elements(*input::BLOCKS_1000_LEN));
@@ -24,7 +24,7 @@ fn build_1000_blocks(
             b.iter_batched(
                 input::blocks_1000,
                 |input| {
-                    let (queue, actor) = umi_app::create(app, buffer_size);
+                    let (queue, actor) = umi_app::create(&mut app, buffer_size);
 
                     runtime.block_on(umi_app::run_with_actor(actor, async {
                         for msg in input {

--- a/server/src/dependency/heed.rs
+++ b/server/src/dependency/heed.rs
@@ -271,7 +271,7 @@ fn create_db() -> umi_storage_heed::Env {
 
     let env = unsafe {
         EnvOpenOptions::new()
-            .max_readers(16348) // TODO: Cleanup readers on shutdown
+            .max_readers(16384)
             .max_dbs(umi_storage_heed::DATABASES.len() as u32)
             .map_size(1024 * 1024 * 1024 * 1024) // 1 TiB
             .open(path)

--- a/server/src/dependency/in_memory.rs
+++ b/server/src/dependency/in_memory.rs
@@ -105,7 +105,7 @@ impl<'db> umi_app::Dependencies<'db> for InMemoryDependencies {
         CommandActor::on_tx_batch_in_memory()
     }
 
-    fn payload_queries() -> Self::PayloadQueries {
+    fn payload_queries(&self) -> Self::PayloadQueries {
         umi_blockchain::payload::InMemoryPayloadQueries::new()
     }
 

--- a/server/src/dependency/in_memory.rs
+++ b/server/src/dependency/in_memory.rs
@@ -13,6 +13,8 @@ pub fn dependencies() -> Dependency {
     InMemoryDependencies::new()
 }
 
+unsafe impl Sync for InMemoryDependencies {}
+
 pub struct InMemoryDependencies {
     memory_reader: umi_blockchain::in_memory::SharedMemoryReader,
     memory: Option<umi_blockchain::in_memory::SharedMemory>,
@@ -62,14 +64,14 @@ impl Default for InMemoryDependencies {
     }
 }
 
-impl umi_app::Dependencies for InMemoryDependencies {
+impl<'db> umi_app::Dependencies<'db> for InMemoryDependencies {
     type BlockQueries = umi_blockchain::block::InMemoryBlockQueries;
     type BlockRepository = umi_blockchain::block::InMemoryBlockRepository;
     type BlockHashLookup = umi_app::SharedBlockHashCache;
     type BlockHashWriter = umi_app::SharedBlockHashCache;
-    type OnPayload = umi_app::OnPayload<Application<Self>>;
-    type OnTx = umi_app::OnTx<Application<Self>>;
-    type OnTxBatch = umi_app::OnTxBatch<Application<Self>>;
+    type OnPayload = umi_app::OnPayload<Application<'db, Self>>;
+    type OnTx = umi_app::OnTx<Application<'db, Self>>;
+    type OnTxBatch = umi_app::OnTxBatch<Application<'db, Self>>;
     type PayloadQueries = umi_blockchain::payload::InMemoryPayloadQueries;
     type ReceiptQueries = umi_blockchain::receipt::InMemoryReceiptQueries;
     type ReceiptRepository = umi_blockchain::receipt::InMemoryReceiptRepository;
@@ -91,15 +93,15 @@ impl umi_app::Dependencies for InMemoryDependencies {
         umi_blockchain::block::InMemoryBlockRepository::new()
     }
 
-    fn on_payload() -> &'static Self::OnPayload {
+    fn on_payload() -> &'db Self::OnPayload {
         CommandActor::on_payload_in_memory()
     }
 
-    fn on_tx() -> &'static Self::OnTx {
+    fn on_tx() -> &'db Self::OnTx {
         CommandActor::on_tx_in_memory()
     }
 
-    fn on_tx_batch() -> &'static Self::OnTxBatch {
+    fn on_tx_batch() -> &'db Self::OnTxBatch {
         CommandActor::on_tx_batch_in_memory()
     }
 

--- a/server/src/dependency/shared.rs
+++ b/server/src/dependency/shared.rs
@@ -7,7 +7,10 @@ use {
 
 pub fn create(
     genesis_config: &GenesisConfig,
-) -> (Application<Dependency>, ApplicationReader<ReaderDependency>) {
+) -> (
+    Application<'static, Dependency>,
+    ApplicationReader<'static, ReaderDependency>,
+) {
     let deps = dependencies();
     let reader_deps = deps.reader();
 

--- a/server/src/tests/test_context.rs
+++ b/server/src/tests/test_context.rs
@@ -16,15 +16,15 @@ use {
 
 const DEPOSIT_TX: &[u8] = &hex!("7ef8f8a032595a51f0561028c684fbeeb46c7221a34be9a2eedda60a93069dd77320407e94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e2000000000000000000000000000000000000000006807cdc800000000000000220000000000000000000000000000000000000000000000000000000000a68a3a000000000000000000000000000000000000000000000000000000000000000198663a8bf712c08273a02876877759b43dc4df514214cc2f6008870b9a8503380000000000000000000000008c67a7b8624044f8f672e9ec374dfa596f01afb9");
 
-pub struct TestContext {
+pub struct TestContext<'test> {
     pub genesis_config: GenesisConfig,
     pub queue: CommandQueue,
-    pub reader: ApplicationReader<dependency::ReaderDependency>,
+    pub reader: ApplicationReader<'test, dependency::ReaderDependency>,
     head: B256,
     timestamp: u64,
 }
 
-impl TestContext {
+impl TestContext<'static> {
     pub async fn run<'f, F, FU>(mut future: FU) -> anyhow::Result<()>
     where
         F: Future<Output = anyhow::Result<()>> + Send + 'f,
@@ -38,7 +38,7 @@ impl TestContext {
         let timestamp = genesis_block.block.header.timestamp;
         app.genesis_update(genesis_block);
 
-        let (queue, state) = umi_app::create(&mut app, 10);
+        let (queue, state) = umi_app::create(app, 10);
 
         let ctx = Self {
             genesis_config,
@@ -179,10 +179,10 @@ impl TestContext {
     }
 }
 
-pub async fn handle_request<T: DeserializeOwned>(
+pub async fn handle_request<'reader, T: DeserializeOwned>(
     request: serde_json::Value,
     queue: &CommandQueue,
-    app: ApplicationReader<impl Dependencies>,
+    app: ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> anyhow::Result<T> {
     let response = umi_api::request::handle(
         request.clone(),

--- a/server/src/tests/test_context.rs
+++ b/server/src/tests/test_context.rs
@@ -38,7 +38,7 @@ impl TestContext<'static> {
         let timestamp = genesis_block.block.header.timestamp;
         app.genesis_update(genesis_block);
 
-        let (queue, state) = umi_app::create(app, 10);
+        let (queue, state) = umi_app::create(&mut app, 10);
 
         let ctx = Self {
             genesis_config,

--- a/storage/heed/src/block.rs
+++ b/storage/heed/src/block.rs
@@ -38,7 +38,7 @@ impl HeedBlockRepository<'_> {
 
 impl<'db> BlockRepository for HeedBlockRepository<'db> {
     type Err = heed::Error;
-    type Storage = &'db heed::Env;
+    type Storage = heed::Env;
 
     fn add(&mut self, env: &mut Self::Storage, block: ExtendedBlock) -> Result<(), Self::Err> {
         let mut transaction = env.write_txn()?;
@@ -98,7 +98,7 @@ impl HeedBlockQueries<'_> {
 
 impl<'db> BlockQueries for HeedBlockQueries<'db> {
     type Err = heed::Error;
-    type Storage = &'db heed::Env;
+    type Storage = heed::Env;
 
     fn by_hash(
         &self,

--- a/storage/heed/src/evm.rs
+++ b/storage/heed/src/evm.rs
@@ -36,11 +36,11 @@ impl From<heed::Error> for Error {
 
 #[derive(Debug, Clone)]
 pub struct HeedStorageTrieRepository {
-    env: Arc<heed::Env>,
+    env: heed::Env,
 }
 
 impl HeedStorageTrieRepository {
-    pub const fn new(env: Arc<heed::Env>) -> Self {
+    pub const fn new(env: heed::Env) -> Self {
         Self { env }
     }
 }

--- a/storage/heed/src/evm_storage_trie.rs
+++ b/storage/heed/src/evm_storage_trie.rs
@@ -5,7 +5,6 @@ use {
     },
     eth_trie::DB,
     heed::RoTxn,
-    std::sync::Arc,
     umi_evm_ext::state::DbWithRoot,
     umi_shared::primitives::{Address, B256},
 };
@@ -20,12 +19,12 @@ pub const DB: &str = "evm_storage_trie";
 pub const ROOT_DB: &str = "evm_storage_trie_root";
 
 pub struct HeedEthStorageTrieDb {
-    env: Arc<heed::Env>,
+    env: heed::Env,
     account: Address,
 }
 
 impl HeedEthStorageTrieDb {
-    pub fn new(env: Arc<heed::Env>, account: Address) -> Self {
+    pub fn new(env: heed::Env, account: Address) -> Self {
         Self { env, account }
     }
 

--- a/storage/heed/src/payload.rs
+++ b/storage/heed/src/payload.rs
@@ -17,12 +17,12 @@ pub type Db = heed::Database<Key, Value>;
 pub const DB: &str = "payload";
 
 #[derive(Debug, Clone)]
-pub struct HeedPayloadQueries<'db> {
-    env: &'db heed::Env,
+pub struct HeedPayloadQueries {
+    env: heed::Env,
 }
 
-impl<'db> HeedPayloadQueries<'db> {
-    pub const fn new(env: &'db heed::Env) -> Self {
+impl HeedPayloadQueries {
+    pub const fn new(env: heed::Env) -> Self {
         Self { env }
     }
 
@@ -37,9 +37,9 @@ impl<'db> HeedPayloadQueries<'db> {
     }
 }
 
-impl<'db> PayloadQueries for HeedPayloadQueries<'db> {
+impl PayloadQueries for HeedPayloadQueries {
     type Err = heed::Error;
-    type Storage = &'db heed::Env;
+    type Storage = heed::Env;
 
     fn by_hash(
         &self,

--- a/storage/heed/src/receipt.rs
+++ b/storage/heed/src/receipt.rs
@@ -35,7 +35,7 @@ impl HeedReceiptRepository<'_> {
 
 impl<'db> ReceiptRepository for HeedReceiptRepository<'db> {
     type Err = heed::Error;
-    type Storage = &'db heed::Env;
+    type Storage = heed::Env;
 
     fn contains(&self, env: &Self::Storage, transaction_hash: B256) -> Result<bool, Self::Err> {
         let transaction = env.read_txn()?;
@@ -83,7 +83,7 @@ impl HeedReceiptQueries<'_> {
 
 impl<'db> ReceiptQueries for HeedReceiptQueries<'db> {
     type Err = heed::Error;
-    type Storage = &'db heed::Env;
+    type Storage = heed::Env;
 
     fn by_transaction_hash(
         &self,

--- a/storage/heed/src/state.rs
+++ b/storage/heed/src/state.rs
@@ -20,17 +20,17 @@ pub const HEIGHT_DB: &str = "state_height";
 pub const HEIGHT_KEY: u64 = 0;
 
 #[derive(Debug, Clone)]
-pub struct HeedStateRootIndex<'db> {
-    env: &'db heed::Env,
+pub struct HeedStateRootIndex {
+    env: heed::Env,
 }
 
-impl<'db> HeedStateRootIndex<'db> {
-    pub const fn new(env: &'db heed::Env) -> Self {
+impl HeedStateRootIndex {
+    pub const fn new(env: heed::Env) -> Self {
         Self { env }
     }
 }
 
-impl HeightToStateRootIndex for HeedStateRootIndex<'_> {
+impl HeightToStateRootIndex for HeedStateRootIndex {
     type Err = heed::Error;
 
     fn height(&self) -> Result<u64, Self::Err> {

--- a/storage/heed/src/transaction.rs
+++ b/storage/heed/src/transaction.rs
@@ -35,7 +35,7 @@ impl HeedTransactionRepository<'_> {
 
 impl<'db> TransactionRepository for HeedTransactionRepository<'db> {
     type Err = heed::Error;
-    type Storage = &'db heed::Env;
+    type Storage = heed::Env;
 
     fn extend(
         &mut self,
@@ -71,7 +71,7 @@ impl HeedTransactionQueries<'_> {
 
 impl<'db> TransactionQueries for HeedTransactionQueries<'db> {
     type Err = heed::Error;
-    type Storage = &'db heed::Env;
+    type Storage = heed::Env;
 
     fn by_hash(
         &self,

--- a/storage/heed/src/trie.rs
+++ b/storage/heed/src/trie.rs
@@ -20,17 +20,17 @@ pub const DB: &str = "trie";
 pub const ROOT_DB: &str = "trie_root";
 pub const ROOT_KEY: u64 = 0u64;
 
-pub struct HeedEthTrieDb<'db> {
-    env: &'db heed::Env,
+pub struct HeedEthTrieDb {
+    env: heed::Env,
 }
 
-impl<'db> HeedEthTrieDb<'db> {
-    pub fn new(env: &'db heed::Env) -> Self {
+impl HeedEthTrieDb {
+    pub fn new(env: heed::Env) -> Self {
         Self { env }
     }
 }
 
-impl DbWithRoot for HeedEthTrieDb<'_> {
+impl DbWithRoot for HeedEthTrieDb {
     fn root(&self) -> Result<Option<B256>, heed::Error> {
         let transaction = self.env.read_txn()?;
 
@@ -54,7 +54,7 @@ impl DbWithRoot for HeedEthTrieDb<'_> {
     }
 }
 
-impl DB for HeedEthTrieDb<'_> {
+impl DB for HeedEthTrieDb {
     type Error = heed::Error;
 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {

--- a/storage/rocksdb/src/block.rs
+++ b/storage/rocksdb/src/block.rs
@@ -4,7 +4,7 @@ use {
         transaction,
     },
     rocksdb::{AsColumnFamilyRef, DB as RocksDb, IteratorMode, WriteBatchWithTransaction},
-    std::marker::PhantomData,
+    std::{marker::PhantomData, sync::Arc},
     umi_blockchain::{
         block::{BlockQueries, BlockRepository, BlockResponse, ExtendedBlock},
         transaction::ExtendedTransaction,
@@ -32,7 +32,7 @@ impl RocksDbBlockRepository<'_> {
 
 impl<'db> BlockRepository for RocksDbBlockRepository<'db> {
     type Err = rocksdb::Error;
-    type Storage = &'db RocksDb;
+    type Storage = Arc<RocksDb>;
 
     fn add(&mut self, db: &mut Self::Storage, block: ExtendedBlock) -> Result<(), Self::Err> {
         let mut batch = WriteBatchWithTransaction::<false>::default();
@@ -81,7 +81,7 @@ impl RocksDbBlockQueries<'_> {
 
 impl<'db> BlockQueries for RocksDbBlockQueries<'db> {
     type Err = rocksdb::Error;
-    type Storage = &'db RocksDb;
+    type Storage = Arc<RocksDb>;
 
     fn by_hash(
         &self,

--- a/storage/rocksdb/src/payload.rs
+++ b/storage/rocksdb/src/payload.rs
@@ -5,6 +5,7 @@ use {
         transaction,
     },
     rocksdb::{AsColumnFamilyRef, DB as RocksDb},
+    std::sync::Arc,
     umi_blockchain::{
         block::ExtendedBlock,
         payload::{PayloadId, PayloadQueries, PayloadResponse},
@@ -22,12 +23,12 @@ impl ToKey for PayloadId {
 }
 
 #[derive(Debug, Clone)]
-pub struct RocksDbPayloadQueries<'db> {
-    db: &'db RocksDb,
+pub struct RocksDbPayloadQueries {
+    db: Arc<RocksDb>,
 }
 
-impl<'db> RocksDbPayloadQueries<'db> {
-    pub fn new(db: &'db RocksDb) -> Self {
+impl RocksDbPayloadQueries {
+    pub fn new(db: Arc<RocksDb>) -> Self {
         Self { db }
     }
 
@@ -36,13 +37,13 @@ impl<'db> RocksDbPayloadQueries<'db> {
     }
 
     fn cf(&self) -> impl AsColumnFamilyRef + use<'_> {
-        cf(self.db)
+        cf(self.db.as_ref())
     }
 }
 
-impl<'db> PayloadQueries for RocksDbPayloadQueries<'db> {
+impl PayloadQueries for RocksDbPayloadQueries {
     type Err = rocksdb::Error;
-    type Storage = &'db RocksDb;
+    type Storage = Arc<RocksDb>;
 
     fn by_hash(
         &self,

--- a/storage/rocksdb/src/receipt.rs
+++ b/storage/rocksdb/src/receipt.rs
@@ -1,7 +1,7 @@
 use {
     crate::generic::{FromValue, ToValue},
     rocksdb::{AsColumnFamilyRef, DB as RocksDb, WriteBatchWithTransaction},
-    std::marker::PhantomData,
+    std::{marker::PhantomData, sync::Arc},
     umi_blockchain::receipt::{
         ExtendedReceipt, ReceiptQueries, ReceiptRepository, TransactionReceipt,
     },
@@ -27,7 +27,7 @@ impl RocksDbReceiptRepository<'_> {
 
 impl<'db> ReceiptRepository for RocksDbReceiptRepository<'db> {
     type Err = rocksdb::Error;
-    type Storage = &'db RocksDb;
+    type Storage = Arc<RocksDb>;
 
     fn contains(&self, db: &Self::Storage, transaction_hash: B256) -> Result<bool, Self::Err> {
         let cf = cf(db);
@@ -69,7 +69,7 @@ impl RocksDbReceiptQueries<'_> {
 
 impl<'db> ReceiptQueries for RocksDbReceiptQueries<'db> {
     type Err = rocksdb::Error;
-    type Storage = &'db RocksDb;
+    type Storage = Arc<RocksDb>;
 
     fn by_transaction_hash(
         &self,

--- a/storage/rocksdb/src/state.rs
+++ b/storage/rocksdb/src/state.rs
@@ -4,6 +4,7 @@ use {
         generic::{FromKey, ToKey},
     },
     rocksdb::{AsColumnFamilyRef, WriteBatchWithTransaction},
+    std::sync::Arc,
     umi_blockchain::state::HeightToStateRootIndex,
     umi_shared::primitives::B256,
 };
@@ -13,27 +14,24 @@ pub const HEIGHT_COLUMN_FAMILY: &str = "state_height";
 pub const HEIGHT_KEY: &str = "state_height";
 
 #[derive(Debug, Clone)]
-pub struct RocksDbStateRootIndex<'db> {
-    db: &'db RocksDb,
+pub struct RocksDbStateRootIndex {
+    db: Arc<RocksDb>,
 }
 
-impl<'db> RocksDbStateRootIndex<'db> {
-    pub const fn new(db: &'db RocksDb) -> Self {
+impl RocksDbStateRootIndex {
+    pub const fn new(db: Arc<RocksDb>) -> Self {
         Self { db }
     }
 }
 
-impl HeightToStateRootIndex for RocksDbStateRootIndex<'_> {
+impl HeightToStateRootIndex for RocksDbStateRootIndex {
     type Err = rocksdb::Error;
 
-    fn push_state_root(&self, state_root: B256) -> Result<(), Self::Err> {
-        let height = self.height()? + 1;
-        let mut batch = WriteBatchWithTransaction::<false>::default();
-
-        batch.put_cf(&self.cf(), height.to_key(), state_root);
-        batch.put_cf(&self.height_cf(), HEIGHT_KEY, height.to_key());
-
-        self.db.write(batch)
+    fn root_by_height(&self, height: u64) -> Result<Option<B256>, Self::Err> {
+        Ok(self
+            .db
+            .get_pinned_cf(&self.cf(), height.to_key())?
+            .map(|v| B256::new(v.as_ref().try_into().unwrap())))
     }
 
     fn height(&self) -> Result<u64, Self::Err> {
@@ -44,15 +42,18 @@ impl HeightToStateRootIndex for RocksDbStateRootIndex<'_> {
             .unwrap_or(0))
     }
 
-    fn root_by_height(&self, height: u64) -> Result<Option<B256>, Self::Err> {
-        Ok(self
-            .db
-            .get_pinned_cf(&self.cf(), height.to_key())?
-            .map(|v| B256::new(v.as_ref().try_into().unwrap())))
+    fn push_state_root(&self, state_root: B256) -> Result<(), Self::Err> {
+        let height = self.height()? + 1;
+        let mut batch = WriteBatchWithTransaction::<false>::default();
+
+        batch.put_cf(&self.cf(), height.to_key(), state_root);
+        batch.put_cf(&self.height_cf(), HEIGHT_KEY, height.to_key());
+
+        self.db.write(batch)
     }
 }
 
-impl RocksDbStateRootIndex<'_> {
+impl RocksDbStateRootIndex {
     fn height_cf(&self) -> impl AsColumnFamilyRef + use<'_> {
         self.db
             .cf_handle(HEIGHT_COLUMN_FAMILY)

--- a/storage/rocksdb/src/transaction.rs
+++ b/storage/rocksdb/src/transaction.rs
@@ -1,7 +1,7 @@
 use {
     crate::generic::{FromValue, ToValue},
     rocksdb::{AsColumnFamilyRef, DB as RocksDb, WriteBatchWithTransaction},
-    std::marker::PhantomData,
+    std::{marker::PhantomData, sync::Arc},
     umi_blockchain::transaction::{
         ExtendedTransaction, TransactionQueries, TransactionRepository, TransactionResponse,
     },
@@ -27,7 +27,7 @@ impl RocksDbTransactionRepository<'_> {
 
 impl<'db> TransactionRepository for RocksDbTransactionRepository<'db> {
     type Err = rocksdb::Error;
-    type Storage = &'db RocksDb;
+    type Storage = Arc<RocksDb>;
 
     fn extend(
         &mut self,
@@ -63,7 +63,7 @@ impl RocksDbTransactionQueries<'_> {
 
 impl<'db> TransactionQueries for RocksDbTransactionQueries<'db> {
     type Err = rocksdb::Error;
-    type Storage = &'db RocksDb;
+    type Storage = Arc<RocksDb>;
 
     fn by_hash(
         &self,

--- a/storage/rocksdb/src/trie.rs
+++ b/storage/rocksdb/src/trie.rs
@@ -10,12 +10,12 @@ pub const TRIE_COLUMN_FAMILY: &str = "trie";
 pub const ROOT_COLUMN_FAMILY: &str = "trie_root";
 pub const ROOT_KEY: &str = "trie_root";
 
-pub struct RocksEthTrieDb<'db> {
-    db: &'db RocksDb,
+pub struct RocksEthTrieDb {
+    db: Arc<RocksDb>,
 }
 
-impl<'db> RocksEthTrieDb<'db> {
-    pub fn new(db: &'db RocksDb) -> Self {
+impl RocksEthTrieDb {
+    pub fn new(db: Arc<RocksDb>) -> Self {
         Self { db }
     }
 
@@ -32,7 +32,7 @@ impl<'db> RocksEthTrieDb<'db> {
     }
 }
 
-impl DbWithRoot for RocksEthTrieDb<'_> {
+impl DbWithRoot for RocksEthTrieDb {
     fn root(&self) -> Result<Option<B256>, rocksdb::Error> {
         Ok(self
             .db
@@ -45,7 +45,7 @@ impl DbWithRoot for RocksEthTrieDb<'_> {
     }
 }
 
-impl DB for RocksEthTrieDb<'_> {
+impl DB for RocksEthTrieDb {
     type Error = rocksdb::Error;
 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {

--- a/storage/rocksdb/tests/collision.rs
+++ b/storage/rocksdb/tests/collision.rs
@@ -1,6 +1,7 @@
 use {
     eth_trie::DB,
     hex_literal::hex,
+    std::sync::Arc,
     umi_evm_ext::state::DbWithRoot,
     umi_shared::primitives::B256,
     umi_storage_rocksdb::{ROOT_KEY, RocksEthTrieDb},
@@ -11,7 +12,7 @@ mod common;
 #[test]
 fn test_column_families_do_not_collide() {
     let rocks = common::create_db();
-    let db = RocksEthTrieDb::new(&rocks);
+    let db = RocksEthTrieDb::new(Arc::new(rocks));
 
     let random_32_bytes = B256::new(hex!(
         "50596cee391a497683672d9396379f56cd8e96476b844557933f48039c483a81"


### PR DESCRIPTION
### Description
Removes static database variables and makes them instance-based instead.

This makes the `Drop` implementation work, which may do some cleanup.

For example `heed`: https://docs.rs/heed/latest/heed/struct.Env.html#method.prepare_for_closing

Static variables are never dropped and that causes the LMDB do accumulate stale readers on every deploy. Having a stale reader means that there is a reader that no longer exists holding a spot for a reader, whose number is limited. The maximum number of readers is configurable, but without having them cleaned up there cannot be a way to set it to a number that's based on some real limitations.

### Changes
- Remove all `static` variables

### Testing
Running `./docker/host/deploy.sh` repeatedly while setting a low number of `max_readers` in the `heed` configuration in `create_db` function.

### Notes
A bunch of `Arc`s are added in this. In the case of `heed`, the `Arc` is actually on the [inside](https://github.com/meilisearch/heed/blob/main/heed/src/envs/env.rs#L32).

I think the `Arc`s can be avoided by sharing one reference instead. But that reference needs to be borrowed from one layer above `Dependencies`, i.e. the `Dependencies` cannot actually own it (and therefore cannot create the database) because the lifetime of `Dependencies` is much shorter than the lifetime of the database.

Well, I decided to not bother with this for now.