### PR TITLE
feat(server-args): Add database configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,8 +82,8 @@ services:
       dockerfile: ./docker/Dockerfile.op-move
     environment:
       OP_MOVE_AUTH_JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
+      OP_MOVE_DB_PURGE: ${OP_MOVE_DB_PURGE:-false}
       OP_GETH_ADDR: "op-geth"
-      PURGE: ${PURGE:-0}
     networks:
       - localnet
     volumes:

--- a/server/args/src/stack.rs
+++ b/server/args/src/stack.rs
@@ -74,7 +74,11 @@ impl<L: Layer> ConfigBuilder<L> {
 mod tests {
     use {
         super::*,
-        crate::declaration::{AuthSocket, HttpSocket, OptionalAuthSocket, OptionalHttpSocket},
+        crate::{
+            declaration::{AuthSocket, HttpSocket, OptionalAuthSocket, OptionalHttpSocket},
+            Database, DatabaseBackend, OptionalDatabase,
+        },
+        std::path::Path,
     };
 
     pub struct StubLayer(OptionalConfig);
@@ -102,6 +106,11 @@ mod tests {
                     addr: Some(overridden_http_addr),
                 }),
                 max_buffered_commands: Some(1),
+                db: Some(OptionalDatabase {
+                    backend: Some(DatabaseBackend::InMemory),
+                    dir: Some(Path::new("db").into()),
+                    purge: Some(false),
+                }),
             }))
             .layer(StubLayer(OptionalConfig {
                 auth: None,
@@ -109,6 +118,7 @@ mod tests {
                     addr: Some(http_addr),
                 }),
                 max_buffered_commands: Some(10),
+                ..Default::default()
             }))
             .try_build()
             .unwrap();
@@ -119,6 +129,11 @@ mod tests {
             },
             http: HttpSocket { addr: http_addr },
             max_buffered_commands: 10,
+            db: Database {
+                backend: DatabaseBackend::InMemory,
+                dir: Path::new("db").into(),
+                purge: false,
+            },
         };
 
         assert_eq!(actual_config, expected_config);

--- a/server/benches/perf/queue/tests.rs
+++ b/server/benches/perf/queue/tests.rs
@@ -9,6 +9,7 @@ use {
     umi_app::{Application, DependenciesThreadSafe},
     umi_genesis::config::GenesisConfig,
     umi_server::initialize_app,
+    umi_server_args::Database,
 };
 
 fn build_1000_blocks<'app>(
@@ -47,7 +48,7 @@ fn bench_build_1000_blocks_with_queue_size(bencher: &mut Criterion) -> impl Term
         .into_iter()
         .rev()
     {
-        let (mut app, _app_reader) = initialize_app(&GenesisConfig::default());
+        let (mut app, _reader) = initialize_app(Database::default(), &GenesisConfig::default());
 
         app.genesis_update(input::GENESIS);
 

--- a/server/src/dependency/in_memory.rs
+++ b/server/src/dependency/in_memory.rs
@@ -9,7 +9,7 @@ pub type Dependency = InMemoryDependencies;
 // TODO: make the same separation as for other backends
 pub type ReaderDependency = InMemoryDependencies;
 
-pub fn dependencies() -> Dependency {
+pub fn dependencies(_args: umi_server_args::Database) -> Dependency {
     InMemoryDependencies::new()
 }
 

--- a/server/src/dependency/shared.rs
+++ b/server/src/dependency/shared.rs
@@ -6,12 +6,13 @@ use {
 };
 
 pub fn create(
+    args: umi_server_args::Database,
     genesis_config: &GenesisConfig,
 ) -> (
     Application<'static, Dependency>,
     ApplicationReader<'static, ReaderDependency>,
 ) {
-    let deps = dependencies();
+    let deps = dependencies(args);
     let reader_deps = deps.reader();
 
     (

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,12 +1,12 @@
 use {
-    umi_server::DEFAULTS,
+    umi_server::defaults,
     umi_server_args::{CliLayer, ConfigBuilder, EnvLayer, FileLayer},
 };
 
 #[tokio::main]
 async fn main() {
     let args = ConfigBuilder::new()
-        .layer(DEFAULTS)
+        .layer(defaults())
         .layer(FileLayer::toml())
         .layer(EnvLayer::new())
         .layer(CliLayer::new())

--- a/server/src/tests/integration.rs
+++ b/server/src/tests/integration.rs
@@ -1,5 +1,5 @@
 use {
-    crate::DEFAULTS,
+    crate::defaults,
     alloy::{
         contract::CallBuilder,
         dyn_abi::EventExt,
@@ -348,7 +348,7 @@ fn run_op_move(jwt_secret: String) -> Runtime {
     let op_move_runtime = Runtime::new().unwrap();
     op_move_runtime.spawn(crate::run(
         ConfigBuilder::new()
-            .layer(DEFAULTS)
+            .layer(defaults())
             .layer(DefaultLayer::new(OptionalConfig {
                 auth: Some(OptionalAuthSocket {
                     jwt_secret: Some(jwt_secret),

--- a/server/src/tests/test_context.rs
+++ b/server/src/tests/test_context.rs
@@ -12,6 +12,7 @@ use {
     umi_app::{ApplicationReader, CommandQueue, Dependencies},
     umi_blockchain::{payload::StatePayloadId, receipt::TransactionReceipt},
     umi_genesis::config::GenesisConfig,
+    umi_server_args::Database,
 };
 
 const DEPOSIT_TX: &[u8] = &hex!("7ef8f8a032595a51f0561028c684fbeeb46c7221a34be9a2eedda60a93069dd77320407e94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8a4440a5e2000000000000000000000000000000000000000006807cdc800000000000000220000000000000000000000000000000000000000000000000000000000a68a3a000000000000000000000000000000000000000000000000000000000000000198663a8bf712c08273a02876877759b43dc4df514214cc2f6008870b9a8503380000000000000000000000008c67a7b8624044f8f672e9ec374dfa596f01afb9");
@@ -30,8 +31,9 @@ impl TestContext<'static> {
         F: Future<Output = anyhow::Result<()>> + Send + 'f,
         FU: FnMut(Self) -> F + Send,
     {
+        let db = Database::default();
         let genesis_config = GenesisConfig::default();
-        let (mut app, reader) = initialize_app(&genesis_config);
+        let (mut app, reader) = initialize_app(db, &GenesisConfig::default());
 
         let genesis_block = create_genesis_block(&app.block_hash, &genesis_config);
         let head = genesis_block.hash;


### PR DESCRIPTION
### Description
Adds database parameters into the main `Config`.

### Changes
- Add `Database` into `Config`
- Use the `Database` parameters in `create_db` functions

### Testing
:green_circle: Fmt
:green_circle: Clippy
:green_circle: Test

### Notes
#45 