### PR TITLE
Feat: keep track of in-progress payloads to avoid unknown payload errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12349,6 +12349,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "test-case",
+ "tokio",
  "umi-evm-ext",
  "umi-execution",
  "umi-genesis",

--- a/api/src/methods/block_number.rs
+++ b/api/src/methods/block_number.rs
@@ -28,7 +28,7 @@ mod tests {
         umi_blockchain::{
             block::{Eip1559GasFee, InMemoryBlockQueries, InMemoryBlockRepository, UmiBlockHash},
             in_memory::shared_memory,
-            payload::InMemoryPayloadQueries,
+            payload::{InMemoryPayloadQueries, InProgressPayloads},
             receipt::{InMemoryReceiptQueries, InMemoryReceiptRepository, receipt_memory},
             state::InMemoryStateQueries,
             transaction::{InMemoryTransactionQueries, InMemoryTransactionRepository},
@@ -58,13 +58,14 @@ mod tests {
         );
         let evm_storage = InMemoryStorageTrieRepository::new();
         let (receipt_memory_reader, receipt_memory) = receipt_memory::new();
+        let in_progress_payloads = InProgressPayloads::default();
 
         (
             ApplicationReader {
                 genesis_config: genesis_config.clone(),
                 base_token: UmiBaseTokenAccounts::new(AccountAddress::ONE),
                 block_queries: InMemoryBlockQueries,
-                payload_queries: InMemoryPayloadQueries::new(),
+                payload_queries: InMemoryPayloadQueries::new(in_progress_payloads.clone()),
                 receipt_queries: InMemoryReceiptQueries::new(),
                 receipt_memory: receipt_memory_reader.clone(),
                 storage: memory_reader.clone(),
@@ -87,7 +88,7 @@ mod tests {
                 on_payload: CommandActor::on_payload_in_memory(),
                 on_tx: CommandActor::on_tx_noop(),
                 on_tx_batch: CommandActor::on_tx_batch_noop(),
-                payload_queries: InMemoryPayloadQueries::new(),
+                payload_queries: InMemoryPayloadQueries::new(in_progress_payloads),
                 receipt_queries: InMemoryReceiptQueries::new(),
                 receipt_repository: InMemoryReceiptRepository::new(),
                 receipt_memory,

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -41,7 +41,7 @@ pub mod tests {
                 InMemoryBlockQueries, InMemoryBlockRepository, UmiBlockHash,
             },
             in_memory::shared_memory,
-            payload::InMemoryPayloadQueries,
+            payload::{InMemoryPayloadQueries, InProgressPayloads},
             receipt::{InMemoryReceiptQueries, InMemoryReceiptRepository, receipt_memory},
             state::{InMemoryStateQueries, MockStateQueries},
             transaction::{InMemoryTransactionQueries, InMemoryTransactionRepository},
@@ -96,6 +96,7 @@ pub mod tests {
             &mut evm_storage,
         );
         let (receipt_memory_reader, receipt_memory) = receipt_memory::new();
+        let in_progress_payloads = InProgressPayloads::default();
 
         (
             ApplicationReader {
@@ -103,7 +104,7 @@ pub mod tests {
                 base_token: UmiBaseTokenAccounts::new(AccountAddress::ONE),
                 block_hash_lookup: block_hash_cache.clone(),
                 block_queries: InMemoryBlockQueries,
-                payload_queries: InMemoryPayloadQueries::new(),
+                payload_queries: InMemoryPayloadQueries::new(in_progress_payloads.clone()),
                 receipt_queries: InMemoryReceiptQueries::new(),
                 receipt_memory: receipt_memory_reader.clone(),
                 storage: memory_reader.clone(),
@@ -126,7 +127,7 @@ pub mod tests {
                 on_payload: CommandActor::on_payload_in_memory(),
                 on_tx: CommandActor::on_tx_noop(),
                 on_tx_batch: CommandActor::on_tx_batch_noop(),
-                payload_queries: InMemoryPayloadQueries::new(),
+                payload_queries: InMemoryPayloadQueries::new(in_progress_payloads),
                 receipt_queries: InMemoryReceiptQueries::new(),
                 receipt_repository: InMemoryReceiptRepository::new(),
                 receipt_memory,

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -156,7 +156,7 @@ mod tests {
                 InMemoryBlockRepository, UmiBlockHash,
             },
             in_memory::shared_memory,
-            payload::InMemoryPayloadQueries,
+            payload::{InMemoryPayloadQueries, InProgressPayloads},
             receipt::{InMemoryReceiptQueries, InMemoryReceiptRepository, receipt_memory},
             state::InMemoryStateQueries,
             transaction::{InMemoryTransactionQueries, InMemoryTransactionRepository},
@@ -276,6 +276,7 @@ mod tests {
         );
         let (receipt_memory_reader, receipt_memory) = receipt_memory::new();
         let genesis_state_root = genesis_config.initial_state_root;
+        let in_progress_payloads = InProgressPayloads::default();
 
         let mut app = Application::<TestDependencies<_, _, _, _>> {
             mem_pool: Default::default(),
@@ -295,7 +296,7 @@ mod tests {
             on_payload: CommandActor::on_payload_in_memory(),
             on_tx: CommandActor::on_tx_noop(),
             on_tx_batch: CommandActor::on_tx_batch_noop(),
-            payload_queries: InMemoryPayloadQueries::new(),
+            payload_queries: InMemoryPayloadQueries::new(in_progress_payloads.clone()),
             receipt_queries: InMemoryReceiptQueries::new(),
             receipt_repository: InMemoryReceiptRepository::new(),
             receipt_memory,
@@ -347,7 +348,7 @@ mod tests {
             transaction_queries: InMemoryTransactionQueries::new(),
             receipt_memory: receipt_memory_reader,
             receipt_queries: InMemoryReceiptQueries::new(),
-            payload_queries: InMemoryPayloadQueries::new(),
+            payload_queries: InMemoryPayloadQueries::new(in_progress_payloads),
             evm_storage,
         };
         let (queue, state) = umi_app::create(&mut app, 10);

--- a/app/src/command.rs
+++ b/app/src/command.rs
@@ -44,6 +44,10 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
         {
             return;
         }
+        let in_progress_payloads = self.payload_queries.get_in_progress();
+        if in_progress_payloads.start_id(id).is_err() {
+            return;
+        }
 
         // Include transactions from both `payload_attributes` and internal mem-pool
         let transactions_with_metadata = attributes
@@ -135,7 +139,8 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             .extend(
                 &mut self.storage,
                 transactions
-                    .into_iter()
+                    .iter()
+                    .cloned()
                     .enumerate()
                     .map(|(transaction_index, inner)| {
                         ExtendedTransaction::new(
@@ -150,9 +155,12 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             .unwrap();
 
         self.block_hash_writer.push(block_number, block_hash);
-        self.block_repository.add(&mut self.storage, block).unwrap();
+        self.block_repository
+            .add(&mut self.storage, block.clone())
+            .unwrap();
 
         (self.on_payload)(self, id, block_hash);
+        in_progress_payloads.finish_id(block, transactions);
     }
 
     pub fn add_transaction(&mut self, tx: TxEnvelope) {

--- a/app/src/query.rs
+++ b/app/src/query.rs
@@ -10,7 +10,7 @@ use {
     },
     umi_blockchain::{
         block::{BaseGasFee, BlockQueries, BlockResponse, Eip1559GasFee},
-        payload::{PayloadId, PayloadQueries, PayloadResponse},
+        payload::{MaybePayloadResponse, PayloadId, PayloadQueries, PayloadResponse},
         receipt::{ReceiptQueries, TransactionReceipt},
         state::{ProofResponse, StateQueries},
         transaction::{TransactionQueries, TransactionResponse},
@@ -271,11 +271,10 @@ impl<'app, D: Dependencies<'app>> ApplicationReader<'app, D> {
         )?)
     }
 
-    pub fn payload(&self, id: PayloadId) -> Result<PayloadResponse> {
+    pub fn payload(&self, id: PayloadId) -> Result<MaybePayloadResponse> {
         self.payload_queries
             .by_id(&self.storage, id)
-            .map_err(|_| Error::DatabaseState)?
-            .ok_or(Error::User(UserError::InvalidPayloadId(id.into_limbs()[0])))
+            .map_err(|_| Error::DatabaseState)
     }
 
     pub fn payload_by_block_hash(&self, block_hash: B256) -> Result<PayloadResponse> {

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -24,7 +24,7 @@ use {
             InMemoryBlockRepository, UmiBlockHash,
         },
         in_memory::shared_memory,
-        payload::InMemoryPayloadQueries,
+        payload::{InMemoryPayloadQueries, InProgressPayloads},
         receipt::{InMemoryReceiptQueries, InMemoryReceiptRepository, receipt_memory},
         state::{BlockHeight, InMemoryStateQueries, MockStateQueries, StateQueries},
         transaction::{InMemoryTransactionQueries, InMemoryTransactionRepository},
@@ -100,6 +100,7 @@ fn create_app_with_given_queries<SQ: StateQueries + Clone + Send + Sync + 'stati
     );
 
     let (receipt_memory_reader, receipt_memory) = receipt_memory::new();
+    let in_progress_payloads = InProgressPayloads::default();
 
     (
         ApplicationReader {
@@ -107,7 +108,7 @@ fn create_app_with_given_queries<SQ: StateQueries + Clone + Send + Sync + 'stati
             base_token: UmiBaseTokenAccounts::new(AccountAddress::ONE),
             block_queries: InMemoryBlockQueries,
             block_hash_lookup: block_hash_cache.clone(),
-            payload_queries: InMemoryPayloadQueries::new(),
+            payload_queries: InMemoryPayloadQueries::new(in_progress_payloads.clone()),
             receipt_queries: InMemoryReceiptQueries::new(),
             receipt_memory: receipt_memory_reader.clone(),
             storage: memory_reader.clone(),
@@ -127,7 +128,7 @@ fn create_app_with_given_queries<SQ: StateQueries + Clone + Send + Sync + 'stati
             on_payload: CommandActor::on_payload_noop(),
             on_tx: CommandActor::on_tx_noop(),
             on_tx_batch: CommandActor::on_tx_batch_noop(),
-            payload_queries: InMemoryPayloadQueries::new(),
+            payload_queries: InMemoryPayloadQueries::new(in_progress_payloads.clone()),
             receipt_queries: InMemoryReceiptQueries::new(),
             receipt_repository: InMemoryReceiptRepository::new(),
             receipt_memory,
@@ -230,6 +231,7 @@ fn create_app_with_fake_queries(
         trie_db,
         genesis_config.initial_state_root,
     );
+    let in_progress_payloads = InProgressPayloads::default();
 
     (
         ApplicationReader {
@@ -237,7 +239,7 @@ fn create_app_with_fake_queries(
             base_token: UmiBaseTokenAccounts::new(AccountAddress::ONE),
             block_hash_lookup: block_hash_cache.clone(),
             block_queries: InMemoryBlockQueries,
-            payload_queries: InMemoryPayloadQueries::new(),
+            payload_queries: InMemoryPayloadQueries::new(in_progress_payloads.clone()),
             receipt_queries: InMemoryReceiptQueries::new(),
             receipt_memory: receipt_reader.clone(),
             storage: memory_reader.clone(),
@@ -257,7 +259,7 @@ fn create_app_with_fake_queries(
             on_payload: CommandActor::on_payload_in_memory(),
             on_tx: CommandActor::on_tx_in_memory(),
             on_tx_batch: CommandActor::on_tx_batch_in_memory(),
-            payload_queries: InMemoryPayloadQueries::new(),
+            payload_queries: InMemoryPayloadQueries::new(in_progress_payloads.clone()),
             receipt_queries: InMemoryReceiptQueries::new(),
             receipt_repository: InMemoryReceiptRepository::new(),
             receipt_memory,
@@ -484,8 +486,8 @@ fn test_one_payload_can_be_fetched_repeatedly() {
 
     app.start_block_build(Default::default(), payload_id);
 
-    let expected_payload = reader.payload(payload_id).unwrap();
-    let actual_payload = reader.payload(payload_id).unwrap();
+    let expected_payload = reader.payload(payload_id).unwrap().unwrap();
+    let actual_payload = reader.payload(payload_id).unwrap().unwrap();
 
     assert_eq!(expected_payload, actual_payload);
 }
@@ -510,7 +512,7 @@ fn test_older_payload_can_be_fetched_again_successfully() {
         payload_id,
     );
 
-    let expected_payload = reader.payload(payload_id).unwrap();
+    let expected_payload = reader.payload(payload_id).unwrap().unwrap();
 
     let tx = create_transaction(1);
 
@@ -530,7 +532,7 @@ fn test_older_payload_can_be_fetched_again_successfully() {
     // make sure the newer payload is fetchable
     let _ = reader.payload(payload_2_id).unwrap();
 
-    let older_payload = reader.payload(payload_id).unwrap();
+    let older_payload = reader.payload(payload_id).unwrap().unwrap();
 
     assert_eq!(expected_payload, older_payload);
 }
@@ -588,7 +590,7 @@ fn test_txs_from_one_account_have_proper_nonce_ordering() {
         );
     }
 
-    let payload = reader.payload(payload_id).unwrap();
+    let payload = reader.payload(payload_id).unwrap().unwrap();
     assert!(
         payload.execution_payload.transactions.len() == 10,
         "Expected 10 transactions in block, but found {:?}",

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -26,6 +26,7 @@ umi-shared.workspace = true
 umi-state.workspace = true
 op-alloy.workspace = true
 serde.workspace = true
+tokio.workspace = true
 sha2.workspace = true
 evmap.workspace = true
 

--- a/blockchain/src/payload/mod.rs
+++ b/blockchain/src/payload/mod.rs
@@ -5,5 +5,8 @@ mod read;
 pub use {
     id::{NewPayloadId, NewPayloadIdInput, PayloadId, StatePayloadId},
     in_memory::InMemoryPayloadQueries,
-    read::{BlobsBundle, ExecutionPayload, PayloadQueries, PayloadResponse, Withdrawal},
+    read::{
+        AlreadyStarted, BlobsBundle, ExecutionPayload, InProgressPayloads, MaybePayloadResponse,
+        PayloadQueries, PayloadResponse, Withdrawal,
+    },
 };

--- a/blockchain/src/payload/read.rs
+++ b/blockchain/src/payload/read.rs
@@ -2,7 +2,12 @@ use {
     crate::{block::ExtendedBlock, payload::id::PayloadId},
     alloy::eips::eip2718::Encodable2718,
     op_alloy::consensus::OpTxEnvelope,
-    std::fmt::Debug,
+    std::{
+        collections::hash_map::{Entry, HashMap},
+        fmt::Debug,
+        sync::{Arc, RwLock},
+    },
+    tokio::sync::broadcast,
     umi_shared::primitives::{Address, B256, B2048, Bytes, U64, U256},
 };
 
@@ -101,6 +106,74 @@ pub struct BlobsBundle {
     pub blobs: Vec<Bytes>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AlreadyStarted;
+
+pub enum MaybePayloadResponse {
+    Unknown,
+    Some(PayloadResponse),
+    Delayed(broadcast::Receiver<PayloadResponse>),
+}
+
+impl MaybePayloadResponse {
+    pub fn is_some(&self) -> bool {
+        matches!(self, Self::Some(_))
+    }
+
+    pub fn unwrap(self) -> PayloadResponse {
+        match self {
+            Self::Some(response) => response,
+            Self::Unknown | Self::Delayed(_) => {
+                panic!("Unwrap unknown or delayed payload response")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct InProgressPayloads {
+    inner: Arc<RwLock<HashMap<PayloadId, broadcast::Sender<PayloadResponse>>>>,
+}
+
+impl InProgressPayloads {
+    pub fn get_delayed(&self, id: &PayloadId) -> Option<broadcast::Receiver<PayloadResponse>> {
+        self.inner
+            .read()
+            .expect("Lock is not poisoned")
+            .get(id)
+            .map(|sender| sender.subscribe())
+    }
+
+    pub fn start_id(&self, id: PayloadId) -> Result<(), AlreadyStarted> {
+        let mut in_progress = self.inner.write().expect("Lock is not poisoned");
+        match in_progress.entry(id) {
+            Entry::Vacant(entry) => {
+                let (sender, _) = broadcast::channel(1);
+                entry.insert(sender);
+                Ok(())
+            }
+            Entry::Occupied(_) => Err(AlreadyStarted),
+        }
+    }
+
+    pub fn finish_id(
+        &self,
+        block: ExtendedBlock,
+        transactions: impl IntoIterator<Item = op_alloy::consensus::OpTxEnvelope>,
+    ) {
+        let id = block.payload_id;
+        let response = PayloadResponse::from_block_with_transactions(block, transactions);
+        if let Some(sender) = self
+            .inner
+            .write()
+            .expect("Lock is not poisoned")
+            .remove(&id)
+        {
+            sender.send(response).ok();
+        }
+    }
+}
+
 pub trait PayloadQueries {
     type Err: Debug;
     type Storage;
@@ -115,7 +188,9 @@ pub trait PayloadQueries {
         &self,
         storage: &Self::Storage,
         id: PayloadId,
-    ) -> Result<Option<PayloadResponse>, Self::Err>;
+    ) -> Result<MaybePayloadResponse, Self::Err>;
+
+    fn get_in_progress(&self) -> InProgressPayloads;
 }
 
 #[cfg(any(feature = "test-doubles", test))]
@@ -138,8 +213,12 @@ mod test_doubles {
             &self,
             _: &Self::Storage,
             _: PayloadId,
-        ) -> Result<Option<PayloadResponse>, Self::Err> {
-            Ok(None)
+        ) -> Result<MaybePayloadResponse, Self::Err> {
+            Ok(MaybePayloadResponse::Unknown)
+        }
+
+        fn get_in_progress(&self) -> InProgressPayloads {
+            InProgressPayloads::default()
         }
     }
 }

--- a/server/src/dependency/heed.rs
+++ b/server/src/dependency/heed.rs
@@ -17,15 +17,18 @@ pub type ReaderDependency = HeedReaderDependencies;
 pub fn dependencies(args: umi_server_args::Database) -> Dependency {
     HeedDependencies {
         db: create_db(args),
+        in_progress_payloads: Default::default(),
     }
 }
 
 pub struct HeedDependencies {
     db: umi_storage_heed::Env,
+    in_progress_payloads: umi_blockchain::payload::InProgressPayloads,
 }
 
 pub struct HeedReaderDependencies {
     db: umi_storage_heed::Env,
+    in_progress_payloads: umi_blockchain::payload::InProgressPayloads,
 }
 
 impl HeedDependencies {
@@ -33,6 +36,7 @@ impl HeedDependencies {
     pub fn reader(&self) -> HeedReaderDependencies {
         HeedReaderDependencies {
             db: self.db.clone(),
+            in_progress_payloads: self.in_progress_payloads.clone(),
         }
     }
 }
@@ -92,7 +96,7 @@ impl<'db> umi_app::Dependencies<'db> for HeedDependencies {
     }
 
     fn payload_queries(&self) -> Self::PayloadQueries {
-        payload::HeedPayloadQueries::new(self.db.clone())
+        payload::HeedPayloadQueries::new(self.db.clone(), self.in_progress_payloads.clone())
     }
 
     fn receipt_queries() -> Self::ReceiptQueries {
@@ -205,7 +209,7 @@ impl<'db> umi_app::Dependencies<'db> for HeedReaderDependencies {
     }
 
     fn payload_queries(&self) -> Self::PayloadQueries {
-        payload::HeedPayloadQueries::new(self.db.clone())
+        payload::HeedPayloadQueries::new(self.db.clone(), self.in_progress_payloads.clone())
     }
 
     fn receipt_queries() -> Self::ReceiptQueries {

--- a/server/src/dependency/in_memory.rs
+++ b/server/src/dependency/in_memory.rs
@@ -23,6 +23,7 @@ pub struct InMemoryDependencies {
     trie_db: Arc<umi_state::InMemoryTrieDb>,
     evm_storage_tries: umi_evm_ext::state::InMemoryStorageTrieRepository,
     block_hash_cache: SharedBlockHashCache,
+    in_progress_payloads: umi_blockchain::payload::InProgressPayloads,
 }
 
 impl InMemoryDependencies {
@@ -39,6 +40,7 @@ impl InMemoryDependencies {
             trie_db: Arc::new(umi_state::InMemoryTrieDb::empty()),
             evm_storage_tries: umi_evm_ext::state::InMemoryStorageTrieRepository::new(),
             block_hash_cache: SharedBlockHashCache::default(),
+            in_progress_payloads: Default::default(),
         }
     }
 
@@ -54,6 +56,7 @@ impl InMemoryDependencies {
             trie_db: self.trie_db.clone(),
             evm_storage_tries: self.evm_storage_tries.clone(),
             block_hash_cache: self.block_hash_cache.clone(),
+            in_progress_payloads: self.in_progress_payloads.clone(),
         }
     }
 }
@@ -106,7 +109,7 @@ impl<'db> umi_app::Dependencies<'db> for InMemoryDependencies {
     }
 
     fn payload_queries(&self) -> Self::PayloadQueries {
-        umi_blockchain::payload::InMemoryPayloadQueries::new()
+        umi_blockchain::payload::InMemoryPayloadQueries::new(self.in_progress_payloads.clone())
     }
 
     fn receipt_queries() -> Self::ReceiptQueries {

--- a/server/src/dependency/rocksdb.rs
+++ b/server/src/dependency/rocksdb.rs
@@ -14,15 +14,18 @@ pub type ReaderDependency = RocksDbReaderDependencies;
 pub fn dependencies(args: umi_server_args::Database) -> Dependency {
     RocksDbDependencies {
         db: Arc::new(create_db(args)),
+        in_progress_payloads: Default::default(),
     }
 }
 
 pub struct RocksDbDependencies {
     db: Arc<umi_storage_rocksdb::RocksDb>,
+    in_progress_payloads: umi_blockchain::payload::InProgressPayloads,
 }
 
 pub struct RocksDbReaderDependencies {
     db: Arc<umi_storage_rocksdb::RocksDb>,
+    in_progress_payloads: umi_blockchain::payload::InProgressPayloads,
 }
 
 impl RocksDbDependencies {
@@ -30,6 +33,7 @@ impl RocksDbDependencies {
     pub fn reader(&self) -> ReaderDependency {
         RocksDbReaderDependencies {
             db: self.db.clone(),
+            in_progress_payloads: self.in_progress_payloads.clone(),
         }
     }
 }
@@ -91,7 +95,10 @@ impl<'db> umi_app::Dependencies<'db> for RocksDbDependencies {
     }
 
     fn payload_queries(&self) -> Self::PayloadQueries {
-        umi_storage_rocksdb::payload::RocksDbPayloadQueries::new(self.db.clone())
+        umi_storage_rocksdb::payload::RocksDbPayloadQueries::new(
+            self.db.clone(),
+            self.in_progress_payloads.clone(),
+        )
     }
 
     fn receipt_queries() -> Self::ReceiptQueries {
@@ -210,7 +217,10 @@ impl<'db> umi_app::Dependencies<'db> for RocksDbReaderDependencies {
     }
 
     fn payload_queries(&self) -> Self::PayloadQueries {
-        umi_storage_rocksdb::payload::RocksDbPayloadQueries::new(self.db.clone())
+        umi_storage_rocksdb::payload::RocksDbPayloadQueries::new(
+            self.db.clone(),
+            self.in_progress_payloads.clone(),
+        )
     }
 
     fn receipt_queries() -> Self::ReceiptQueries {


### PR DESCRIPTION
### Description
Adds a small in-memory cache for in-progress forkchoice update payloads (i.e. blocks). This cache allows the RPC to delay a bit for a block to finish building before returning a result from `engine_getPayload`, this preventing some unknown payload errors. The purpose of this change is to try to address the slowness of the faucet on Devnet.

### Changes
- New synchronous (via `RwLock`) in-memory cache of in-progress blocks.
- RPC uses this cache to know when it should wait for a block to finish processing instead of returning an unknown payload error.

### Testing
- Integration testing shows this change does have an improvement on deposit times

### Notes
- This change will not necessarily stop all unknown payload errors. If the `engine_getPayload` call comes before the block even starts building (e.g. because the command queue is very backed up) then this in-progress tracker will not help. However, I think this change should prevent errors most of the time because usually `op-move` will start building the block right away and thus it will be in progress before the `engine_getPayload` RPC call arrives.