### PR TITLE
Fix(build): Map transaction type

### DIFF
--- a/app/src/command.rs
+++ b/app/src/command.rs
@@ -135,7 +135,7 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             .unwrap();
 
         (self.on_payload)(self, id, block_hash);
-        in_progress_payloads.finish_id(block, transactions);
+        in_progress_payloads.finish_id(block, transactions.into_iter().map(Into::into));
     }
 
     pub fn add_transaction(&mut self, tx: NormalizedEthTransaction) {


### PR DESCRIPTION
### Description
There was a hidden  merge conflict between #431 and #424 which broke the build on `main`. This PR fixes the problem.

### Changes
- Map `NormalizedExtendedTxEnvelope` into `OpTxEnvelope`

### Testing
- Existing tests.