### PR TITLE
ci: Free up disk space in `deploy` workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,6 +20,8 @@ jobs:
       packages: write
       contents: read
     steps:
+      - name: Free up disk space
+        run: rm -rf /opt/hostedtoolcache
       - name: Clone repository
         uses: actions/checkout@v4
       - name: Log in to the registry


### PR DESCRIPTION
### Description
To ensure there is enough disk space, just like in the `build` workflow, this change removes some junk from the CI image.

### Changes
- Add free up disk space step into the `build` job

### Testing
Using the CI
