### PR TITLE
build(docker): Add cache configuration

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Log in to the registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Set up Docker Buildx # Driver that supports cache export
+        uses: docker/setup-buildx-action@v3
       - name: Pull images
         run: docker compose pull
         continue-on-error: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@ services:
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.foundry
+      cache_from:
+        - type=registry,ref=ghcr.io/uminetwork/foundry:latest-cache,mode=max
+      cache_to:
+        - type=registry,ref=ghcr.io/uminetwork/foundry:latest-cache,mode=max
     deploy:
       replicas: 0
 
@@ -14,6 +18,10 @@ services:
       dockerfile: ./docker/Dockerfile.optimism
       additional_contexts:
         ghcr.io/uminetwork/foundry: "service:foundry"
+      cache_from:
+        - type=registry,ref=ghcr.io/uminetwork/optimism:latest-cache,mode=max
+      cache_to:
+        - type=registry,ref=ghcr.io/uminetwork/optimism:latest-cache,mode=max
     depends_on:
       - foundry
     deploy:
@@ -29,6 +37,10 @@ services:
       additional_contexts:
         ghcr.io/uminetwork/optimism: "service:optimism"
         ghcr.io/uminetwork/foundry: "service:foundry"
+      cache_from:
+        - type=registry,ref=ghcr.io/uminetwork/op-node:latest-cache,mode=max
+      cache_to:
+        - type=registry,ref=ghcr.io/uminetwork/op-node:latest-cache,mode=max
     environment:
       JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
     networks:
@@ -47,6 +59,10 @@ services:
       additional_contexts:
         ghcr.io/uminetwork/optimism: "service:optimism"
         ghcr.io/uminetwork/foundry: "service:foundry"
+      cache_from:
+        - type=registry,ref=ghcr.io/uminetwork/op-batcher:latest-cache,mode=max
+      cache_to:
+        - type=registry,ref=ghcr.io/uminetwork/op-batcher:latest-cache,mode=max
     networks:
       - localnet
     depends_on:
@@ -63,6 +79,10 @@ services:
       additional_contexts:
         ghcr.io/uminetwork/optimism: "service:optimism"
         ghcr.io/uminetwork/foundry: "service:foundry"
+      cache_from:
+        - type=registry,ref=ghcr.io/uminetwork/op-proposer:latest-cache,mode=max
+      cache_to:
+        - type=registry,ref=ghcr.io/uminetwork/op-proposer:latest-cache,mode=max
     networks:
       - localnet
     depends_on:
@@ -79,6 +99,10 @@ services:
       additional_contexts:
         ghcr.io/uminetwork/optimism: "service:optimism"
         ghcr.io/uminetwork/foundry: "service:foundry"
+      cache_from:
+        - type=registry,ref=ghcr.io/uminetwork/op-geth:latest-cache,mode=max
+      cache_to:
+        - type=registry,ref=ghcr.io/uminetwork/op-geth:latest-cache,mode=max
     environment:
       JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
     networks:
@@ -94,6 +118,10 @@ services:
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.op-move
+      cache_from:
+        - type=registry,ref=ghcr.io/uminetwork/op-move:latest-cache,mode=max
+      cache_to:
+        - type=registry,ref=ghcr.io/uminetwork/op-move:latest-cache,mode=max
     environment:
       OP_MOVE_AUTH_JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
       OP_MOVE_DB_PURGE: ${OP_MOVE_DB_PURGE:-false}
@@ -135,6 +163,10 @@ services:
       dockerfile: ./docker/Dockerfile.geth
       additional_contexts:
         ghcr.io/uminetwork/foundry: "service:foundry"
+      cache_from:
+        - type=registry,ref=ghcr.io/uminetwork/geth:latest-cache,mode=max
+      cache_to:
+        - type=registry,ref=ghcr.io/uminetwork/geth:latest-cache,mode=max
     networks:
       - localnet
     depends_on:


### PR DESCRIPTION
### Description
Adds cache configuration into `deploy` workflow.

In the best case it shaves off over an **hour and a quarter** as you can see in the difference between the two attempts of this workflow run https://github.com/UmiNetwork/op-move/actions/runs/15927637949.

### Changes
- Add `cache_from` and `cache_to` imports and exports of cache layers

### Testing
Using the CI