### PR TITLE
fix(server-args): Merge genesis config layers instead of replacing them

### DIFF
--- a/server/args/src/declaration.rs
+++ b/server/args/src/declaration.rs
@@ -217,8 +217,11 @@ impl OptionalConfig {
             (Some(ours), Some(theirs)) => Some(ours.apply(theirs)),
             (ours, theirs) => theirs.or(ours),
         };
+        self.genesis = match (self.genesis, genesis) {
+            (Some(ours), Some(theirs)) => Some(ours.apply(theirs)),
+            (ours, theirs) => theirs.or(ours),
+        };
         self.max_buffered_commands = max_buffered_commands.or(self.max_buffered_commands);
-        self.genesis = genesis.or(self.genesis);
 
         self
     }


### PR DESCRIPTION
### Description
Fixes the genesis config being overwritten by the next config layer instead of merged.

### Changes
- Merge genesis config layers instead of replacing it

### Testing
Using docker