### PR TITLE
Chore: Remove outdated comment on transfer_eth

### DIFF
--- a/execution/src/eth_token.rs
+++ b/execution/src/eth_token.rs
@@ -200,8 +200,6 @@ pub fn transfer_eth<G: GasMeter>(
         &[],
     )?;
 
-    // FIXME: transfer function can fail if user has insufficient balance or if the gas meter
-    // is depleted, which is a potential attack vector
     session.execute_entry_function(
         function,
         vec![


### PR DESCRIPTION
### Description
Removes an outdated comment. Closes #257 
The issue this comment references is no longer relevant because we always handle the error coming from uses of `eth_transfer`. Either the error is impossible (as in `refund_gas_cost` where the `UnmeteredGasMeter` is used) or the error is mapped to an invalid transaction (as is the case when charging for gas at the start of a transaction) or the error is kept as a user error in the VM result (e.g. when doing a simple base token transfer transaction).

### Changes
- None

### Testing
- N/A