### PR TITLE
Feat(stability): remove/replace unwraps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,9 @@ warp-reverse-proxy = "1"
 evmap = "10"
 toml = "0.8"
 
+[workspace.lints.clippy]
+unwrap_used = "deny"
+
 [patch.crates-io]
 merlin = { git = "https://github.com/aptos-labs/merlin" }
 x25519-dalek = { git = "https://github.com/aptos-labs/x25519-dalek", branch = "zeroize_v1" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -4,6 +4,9 @@ edition.workspace = true
 name = "umi-api"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 alloy.workspace = true
 umi-app.workspace = true

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -12,6 +12,9 @@ test-doubles = [
     "umi-evm-ext/test-doubles",
 ]
 
+[lints]
+workspace = true
+
 [dependencies]
 alloy.workspace = true
 alloy-trie.workspace = true

--- a/app/src/command.rs
+++ b/app/src/command.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
         Application, Dependencies, ExecutionOutcome, PayloadForExecution,
+        actor::UnrecoverableAppFailure,
         input::{WithExecutionOutcome, WithPayloadAttributes},
     },
     alloy::{consensus::Receipt, primitives::Bloom, rlp::Encodable},
@@ -28,18 +29,27 @@ use {
 
 impl<'app, D: Dependencies<'app>> Application<'app, D> {
     #[tracing::instrument(level = "debug", skip(self, attributes))]
-    pub fn start_block_build(&mut self, attributes: PayloadForExecution, id: PayloadId) {
-        if self
+    pub(crate) fn start_block_build(
+        &mut self,
+        attributes: PayloadForExecution,
+        id: PayloadId,
+    ) -> Result<(), UnrecoverableAppFailure> {
+        let payload_exists = self
             .payload_queries
             .by_id(&self.storage_reader, id)
-            .unwrap()
-            .is_some()
-        {
-            return;
+            .map_err(|e| {
+                tracing::error!(
+                    "Failure during `start_block_build`. Payload queries failed: {e:?}"
+                );
+                UnrecoverableAppFailure
+            })?
+            .is_some();
+        if payload_exists {
+            return Ok(());
         }
         let in_progress_payloads = self.payload_queries.get_in_progress();
         if in_progress_payloads.start_id(id).is_err() {
-            return;
+            return Ok(());
         }
 
         // Include transactions from both `payload_attributes` and internal mem-pool
@@ -48,15 +58,27 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             .iter()
             .cloned()
             .chain(self.mem_pool.drain().map(Into::into))
-            .filter(|tx|
+            .filter_map(|tx|
                 // Do not include transactions we have already processed before
-                !self.receipt_repository.contains(&self.receipt_memory, tx.tx_hash()).unwrap())
-            .collect::<Vec<_>>();
+                match self.receipt_repository.contains(&self.receipt_memory, tx.tx_hash()) {
+                    Ok(false) => Some(Ok(tx)),
+                    Ok(true) => None,
+                    Err(e) => Some(Err(e)),
+                }
+            )
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                tracing::error!("Failure during `start_block_build`. Receipt queries failed: {e:?}");
+                UnrecoverableAppFailure
+            })?;
         let parent = self
             .block_repository
             .latest(&self.storage)
-            .unwrap()
-            .expect("Parent block should exist");
+            .map_err(|e| {
+                tracing::error!("Failure during `start_block_build`. Failed to get latest block from block repository: {e:?}");
+                UnrecoverableAppFailure
+            })?
+            .expect("Block repository is non-empty (must always at least contain genesis)");
         let base_fee = self.gas_fee.base_fee_per_gas(
             parent.block.header.gas_limit,
             parent.block.header.gas_used,
@@ -72,7 +94,7 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             transactions.clone().into_iter(),
             base_fee,
             &header_for_execution,
-        );
+        )?;
 
         let transactions_root = alloy_trie::root::ordered_trie_root(&transactions);
         // TODO: is this the correct withdrawals root calculation?
@@ -108,7 +130,12 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
                     .into_iter()
                     .map(|receipt| receipt.with_block_hash(block_hash)),
             )
-            .unwrap();
+            .map_err(|e| {
+                tracing::error!(
+                    "Failure during `start_block_build`. Failed to write receipts: {e:?}"
+                );
+                UnrecoverableAppFailure
+            })?;
 
         self.transaction_repository
             .extend(
@@ -127,24 +154,38 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
                         )
                     }),
             )
-            .unwrap();
+            .map_err(|e| {
+                tracing::error!(
+                    "Failure during `start_block_build`. Failed to write transactions: {e:?}"
+                );
+                UnrecoverableAppFailure
+            })?;
 
         self.block_hash_writer.push(block_number, block_hash);
         self.block_repository
             .add(&mut self.storage, block.clone())
-            .unwrap();
+            .map_err(|e| {
+                tracing::error!(
+                    "Failure during `start_block_build`. Failed to write produced block: {e:?}"
+                );
+                UnrecoverableAppFailure
+            })?;
 
         (self.on_payload)(self, id, block_hash);
         in_progress_payloads.finish_id(block, transactions.into_iter().map(Into::into));
+        Ok(())
     }
 
     pub fn add_transaction(&mut self, tx: NormalizedEthTransaction) {
         self.mem_pool.insert(tx);
     }
 
-    pub fn genesis_update(&mut self, block: ExtendedBlock) {
+    pub fn genesis_update(
+        &mut self,
+        block: ExtendedBlock,
+    ) -> Result<(), <D::BlockRepository as BlockRepository>::Err> {
         self.block_hash_writer.push(0, block.hash);
-        self.block_repository.add(&mut self.storage, block).unwrap();
+        self.block_repository.add(&mut self.storage, block)
     }
 
     fn execute_transactions(
@@ -152,7 +193,7 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
         transactions: impl Iterator<Item = NormalizedExtendedTxEnvelope>,
         base_fee: U256,
         block_header: &HeaderForExecution,
-    ) -> (ExecutionOutcome, Vec<ExtendedReceipt>) {
+    ) -> Result<(ExecutionOutcome, Vec<ExtendedReceipt>), UnrecoverableAppFailure> {
         let mut total_tip = U256::ZERO;
         let mut receipts = Vec::new();
         let mut transactions = transactions.peekable();
@@ -221,18 +262,16 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
 
             self.on_tx(outcome.changes.move_vm.clone().accounts);
 
-            self.state
-                .apply(outcome.changes.move_vm)
-                .unwrap_or_else(|e| {
-                    panic!("ERROR: state update failed for transaction {normalized_tx:?}\n{e:?}")
-                });
-            self.evm_storage
-                .apply(outcome.changes.evm)
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "ERROR: EVM storage update failed for transaction {normalized_tx:?}\n{e:?}"
-                    )
-                });
+            self.state.apply(outcome.changes.move_vm).map_err(|e| {
+                tracing::error!("State update failed for transaction {normalized_tx:?}\n{e:?}");
+                UnrecoverableAppFailure
+            })?;
+            self.evm_storage.apply(outcome.changes.evm).map_err(|e| {
+                tracing::error!(
+                    "EVM storage update failed for transaction {normalized_tx:?}\n{e:?}"
+                );
+                UnrecoverableAppFailure
+            })?;
 
             cumulative_gas_used = cumulative_gas_used.saturating_add(outcome.gas_used as u128);
 
@@ -300,6 +339,6 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             logs_bloom,
             total_tip,
         };
-        (outcome, receipts)
+        Ok((outcome, receipts))
     }
 }

--- a/app/src/input.rs
+++ b/app/src/input.rs
@@ -2,7 +2,7 @@ use {
     alloy::{primitives::Bloom, rlp::Decodable},
     op_alloy::consensus::OpTxEnvelope,
     umi_blockchain::{
-        block::{ExtendedBlock, Header},
+        block::Header,
         payload::{NewPayloadIdInput, PayloadId},
     },
     umi_execution::transaction::{NormalizedEthTransaction, NormalizedExtendedTxEnvelope},
@@ -67,9 +67,6 @@ pub enum Command {
     },
     AddTransaction {
         tx: NormalizedEthTransaction,
-    },
-    GenesisUpdate {
-        block: ExtendedBlock,
     },
 }
 

--- a/app/src/query.rs
+++ b/app/src/query.rs
@@ -36,11 +36,11 @@ impl<'app, D: Dependencies<'app>> ApplicationReader<'app, D> {
     }
 
     pub fn balance_by_height(&self, address: Address, height: BlockNumberOrTag) -> Result<U256> {
-        Ok(self.state_queries.balance_at(
+        self.state_queries.balance_at(
             &self.evm_storage,
             address.to_move_address(),
             self.resolve_height(height)?,
-        )?)
+        )
     }
 
     pub fn nonce_by_height(&self, address: Address, height: BlockNumberOrTag) -> Result<u64> {

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -449,7 +449,8 @@ fn test_fetched_balances_are_updated_after_transfer_of_funds() {
     app.start_block_build(
         PayloadForExecution::default(),
         U64::from(0x03421ee50df45cacu64),
-    );
+    )
+    .unwrap();
 
     let actual_recipient_balance = reader.balance_by_height(to, Latest).unwrap();
     let expected_recipient_balance = amount;
@@ -475,7 +476,8 @@ fn test_fetched_nonces_are_updated_after_executing_transaction() {
     app.start_block_build(
         PayloadForExecution::default(),
         U64::from(0x03421ee50df45cacu64),
-    );
+    )
+    .unwrap();
 
     let actual_recipient_balance = reader.nonce_by_height(to, Latest).unwrap();
     let expected_recipient_balance = 0;
@@ -500,7 +502,8 @@ fn test_one_payload_can_be_fetched_repeatedly() {
 
     let payload_id = U64::from(0x03421ee50df45cacu64);
 
-    app.start_block_build(PayloadForExecution::default(), payload_id);
+    app.start_block_build(PayloadForExecution::default(), payload_id)
+        .unwrap();
 
     let expected_payload = reader.payload(payload_id).unwrap().unwrap();
     let actual_payload = reader.payload(payload_id).unwrap().unwrap();
@@ -528,7 +531,8 @@ fn test_older_payload_can_be_fetched_again_successfully() {
         .try_into()
         .unwrap(),
         payload_id,
-    );
+    )
+    .unwrap();
 
     let expected_payload = reader.payload(payload_id).unwrap().unwrap();
 
@@ -547,7 +551,8 @@ fn test_older_payload_can_be_fetched_again_successfully() {
         .try_into()
         .unwrap(),
         payload_2_id,
-    );
+    )
+    .unwrap();
 
     // make sure the newer payload is fetchable
     let _ = reader.payload(payload_2_id).unwrap();
@@ -573,7 +578,8 @@ fn test_txs_from_one_account_have_proper_nonce_ordering() {
 
     let payload_id = U64::from(0x03421ee50df45cacu64);
 
-    app.start_block_build(PayloadForExecution::default(), payload_id);
+    app.start_block_build(PayloadForExecution::default(), payload_id)
+        .unwrap();
 
     for (i, tx_hash) in tx_hashes.iter().enumerate() {
         // Get receipt for this transaction
@@ -684,7 +690,8 @@ fn test_fee_history_eip1559_fields() {
     let (reader, mut app) =
         create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10), 1);
 
-    app.start_block_build(PayloadForExecution::default(), U64::from(1));
+    app.start_block_build(PayloadForExecution::default(), U64::from(1))
+        .unwrap();
 
     let result = reader.fee_history(1, Latest, None);
     assert!(result.is_ok());
@@ -717,7 +724,8 @@ fn test_fee_history_empty_vs_full_blocks(num_txs: usize, expect_zero_ratio: bool
         gas_limit: U64::from(1_000_000),
         ..Default::default()
     };
-    app.start_block_build(payload.try_into().unwrap(), U64::from(1));
+    app.start_block_build(payload.try_into().unwrap(), U64::from(1))
+        .unwrap();
 
     let result = reader.fee_history(1, Latest, Some(vec![50.0]));
     assert!(result.is_ok());
@@ -756,7 +764,8 @@ fn test_fee_history_percentile_calculations(
         .try_into()
         .unwrap(),
         U64::from(1),
-    );
+    )
+    .unwrap();
 
     let result = reader.fee_history(1, Latest, Some(percentiles));
     assert!(result.is_ok());
@@ -796,7 +805,8 @@ fn test_fee_history_gas_ratio_progression(tx_counts: Vec<usize>, expect_increasi
             .try_into()
             .unwrap(),
             U64::from(block_num as u64 + 1),
-        );
+        )
+        .unwrap();
     }
 
     let result = reader.fee_history(tx_counts.len() as u64, Latest, None);
@@ -838,7 +848,8 @@ fn test_fee_history_boundary_percentiles() {
         .try_into()
         .unwrap(),
         U64::from(1),
-    );
+    )
+    .unwrap();
 
     let percentiles = vec![0.0, 33.33, 66.66, 100.0];
     let result = reader.fee_history(1, Latest, Some(percentiles));

--- a/app/src/uninit.rs
+++ b/app/src/uninit.rs
@@ -53,15 +53,15 @@ impl<'app> Dependencies<'app> for Uninitialized {
     fn block_repository() -> Self::BlockRepository {}
 
     fn on_payload() -> &'app Self::OnPayload {
-        &|_, _, _| {}
+        &|_, _, _| Ok(())
     }
 
     fn on_tx() -> &'app Self::OnTx {
-        &|_, _| {}
+        &|_, _| Ok(())
     }
 
     fn on_tx_batch() -> &'app Self::OnTxBatch {
-        &|_| {}
+        &|_| Ok(())
     }
 
     fn payload_queries(&self) -> Self::PayloadQueries {}

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -8,6 +8,9 @@ edition.workspace = true
 default = []
 test-doubles = []
 
+[lints]
+workspace = true
+
 [dependencies]
 alloy.workspace = true
 aptos-types.workspace = true

--- a/blockchain/src/block/mod.rs
+++ b/blockchain/src/block/mod.rs
@@ -6,7 +6,14 @@
 
 mod gas;
 mod hash;
+
+// Safety: Unwraps allowed here because
+// (1) in-memory backend is only used in tests
+// (2) all unwraps come from `RwLock` poisoning, which should never happen
+// if the rest of the code does not panic.
+#[allow(clippy::unwrap_used)]
 mod in_memory;
+
 mod read;
 mod write;
 

--- a/blockchain/src/state/read/model.rs
+++ b/blockchain/src/state/read/model.rs
@@ -59,10 +59,10 @@ pub trait StateQueries {
         evm_storage: &impl StorageTrieRepository,
         account: AccountAddress,
         height: BlockHeight,
-    ) -> Result<Balance, state::Error> {
+    ) -> umi_shared::error::Result<Balance> {
         let resolver = self.resolver_at(height)?;
 
-        Ok(quick_get_eth_balance(&account, &resolver, evm_storage))
+        quick_get_eth_balance(&account, &resolver, evm_storage)
     }
 
     /// Queries the blockchain state version corresponding with block `height` for the nonce value

--- a/blockchain/src/state/read/test_doubles.rs
+++ b/blockchain/src/state/read/test_doubles.rs
@@ -21,7 +21,7 @@ impl StateQueries for MockStateQueries {
         _evm_storage: &impl StorageTrieRepository,
         account: AccountAddress,
         height: BlockHeight,
-    ) -> Result<Balance, state::Error> {
+    ) -> umi_shared::error::Result<Balance> {
         assert_eq!(account, self.0);
         assert_eq!(height, self.1);
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/evm-ext/Cargo.toml
+++ b/evm-ext/Cargo.toml
@@ -8,6 +8,9 @@ edition.workspace = true
 default = []
 test-doubles = []
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 auto_impl = "1.2.1"

--- a/evm-ext/src/native_impl.rs
+++ b/evm-ext/src/native_impl.rs
@@ -139,10 +139,7 @@ fn evm_create(
     debug_assert!(ty_args.is_empty(), "No ty_args in EVM native");
     debug_assert_eq!(args.len(), 3, "EVM native args should be from, value, data");
 
-    // Safety: unwrap is safe because of the length check above
-    // Note: the `safely_pop_vec_arg` macro does not work well for `Vec<u8>`
-    // because it has a special runtime representation.
-    let data = args.pop_back().unwrap().value_as::<Vec<u8>>()?;
+    let data = safely_pop_arg!(args, Vec<u8>);
     let value = safely_pop_arg!(args, move_core_types::u256::U256);
     let caller = safely_pop_arg!(args, AccountAddress);
 
@@ -230,10 +227,7 @@ fn pop_evm_args(mut args: VecDeque<Value>) -> SafeNativeResult<EvmCallArgs> {
         "EVM native args should be from, to, value, data"
     );
 
-    // Safety: unwrap is safe because of the length check above
-    // Note: the `safely_pop_vec_arg` macro does not work well for `Vec<u8>`
-    // because it has a special runtime representation.
-    let data = args.pop_back().unwrap().value_as::<Vec<u8>>()?;
+    let data = safely_pop_arg!(args, Vec<u8>);
     let value = safely_pop_arg!(args, move_core_types::u256::U256);
     let to = safely_pop_arg!(args, AccountAddress);
     let caller = safely_pop_arg!(args, AccountAddress);

--- a/evm-ext/src/solidity_abi.rs
+++ b/evm-ext/src/solidity_abi.rs
@@ -73,8 +73,12 @@ pub fn abi_encode_params(
     );
 
     // Safety: unwrap is safe because of the length check above
-    let value = args.pop_back().unwrap();
-    let prefix = args.pop_back().unwrap().value_as::<Vec<u8>>()?;
+    let value = args
+        .pop_back()
+        .ok_or(SafeNativeError::InvariantViolation(PartialVMError::new(
+            StatusCode::INDEX_OUT_OF_BOUNDS,
+        )))?;
+    let prefix = safely_pop_arg!(args, Vec<u8>);
     let ty_arg = safely_pop_type_arg!(ty_args);
 
     // Charge for the lookup of the type (twice because we need to get annotated and not).

--- a/evm-ext/src/state/storage.rs
+++ b/evm-ext/src/state/storage.rs
@@ -313,10 +313,17 @@ impl DB for InMemoryDb {
 
 impl DbWithRoot for InMemoryDb {
     fn root(&self) -> result::Result<Option<B256>, Self::Error> {
+        // Safety: unwrap here is acceptable because
+        // (1) `InMemoryDb` is used in tests only (not production)
+        // (2) Poisoned `RwLock` is an unexpected state (since the code should not panic anywhere)
+        // therefore calls to `read` should always succeed.
+        #[allow(clippy::unwrap_used)]
         Ok(*self.root.read().unwrap())
     }
 
     fn put_root(&self, root: B256) -> result::Result<(), Self::Error> {
+        // Safety: unwrap here is acceptable (see reason above).
+        #[allow(clippy::unwrap_used)]
         self.root.write().unwrap().replace(root);
         Ok(())
     }
@@ -341,6 +348,8 @@ impl InMemoryStorageTrieRepository {
 
 impl StorageTrieDb for InMemoryStorageTrieRepository {
     fn db(&self, account: Address) -> Arc<StagingEthTrieDb<BoxedTrieDb>> {
+        // Safety: unwrap here is acceptable (see reason in `DbWithRoot` implementation).
+        #[allow(clippy::unwrap_used)]
         self.accounts
             .write()
             .unwrap()

--- a/evm-ext/src/type_utils.rs
+++ b/evm-ext/src/type_utils.rs
@@ -1,6 +1,8 @@
 use {
     super::{EVM_NATIVE_ADDRESS, EVM_NATIVE_MODULE, EvmNativeOutcome},
     alloy::hex::ToHexExt,
+    aptos_types::vm_status::StatusCode,
+    move_binary_format::errors::PartialVMError,
     move_core_types::{
         account_address::AccountAddress, identifier::Identifier, language_storage::StructTag,
     },
@@ -86,72 +88,83 @@ pub fn evm_result_to_move_value(result: ExecutionResult) -> Value {
     Value::struct_(Struct::pack(fields))
 }
 
-// Safety: This function has a TON of unwraps in it. It should only be called on
-// results that actually came from calling the EVM native.
-pub fn extract_evm_result(outcome: SerializedReturnValues) -> EvmNativeOutcome {
+pub fn extract_evm_result(
+    outcome: SerializedReturnValues,
+) -> Result<EvmNativeOutcome, PartialVMError> {
+    let malformed = || {
+        PartialVMError::new(StatusCode::ABORT_TYPE_MISMATCH_ERROR)
+            .with_message("Malformed EVM native return value".into())
+    };
+
     let mut return_values = outcome.return_values.into_iter().map(|(bytes, layout)| {
         ValueSerDeContext::new()
             .deserialize(&bytes, &layout)
-            .unwrap()
+            .ok_or_else(|| {
+                PartialVMError::new(StatusCode::ABORT_TYPE_MISMATCH_ERROR)
+                    .with_message("Invalid bytes+layout combination given for EVM native".into())
+            })
     });
 
     let mut evm_result_fields = return_values
         .next()
-        .unwrap()
-        .value_as::<Struct>()
-        .unwrap()
-        .unpack()
-        .unwrap();
+        .ok_or_else(malformed)??
+        .value_as::<Struct>()?
+        .unpack()?;
 
-    assert!(
-        return_values.next().is_none(),
-        "EVM native has only one return value."
-    );
+    if return_values.next().is_some() {
+        return Err(PartialVMError::new(StatusCode::ABORT_TYPE_MISMATCH_ERROR)
+            .with_message("EVM native has only one return value.".into()));
+    }
 
-    let is_success: bool = evm_result_fields.next().unwrap().value_as().unwrap();
-    let output: Vec<u8> = evm_result_fields.next().unwrap().value_as().unwrap();
-    let logs: Vec<Value> = evm_result_fields.next().unwrap().value_as().unwrap();
+    let is_success: bool = evm_result_fields.next().ok_or_else(malformed)?.value_as()?;
+    let output: Vec<u8> = evm_result_fields.next().ok_or_else(malformed)?.value_as()?;
+    let logs: Vec<Value> = evm_result_fields.next().ok_or_else(malformed)?.value_as()?;
     let logs = logs
         .into_iter()
         .map(|value| {
-            let mut fields = value.value_as::<Struct>().unwrap().unpack().unwrap();
+            let mut fields = value.value_as::<Struct>()?.unpack()?;
 
-            let address = fields.next().unwrap().value_as::<AccountAddress>().unwrap();
+            let address = fields
+                .next()
+                .ok_or_else(malformed)?
+                .value_as::<AccountAddress>()?;
             let topics = fields
                 .next()
-                .unwrap()
-                .value_as::<Vector>()
-                .unwrap()
-                .unpack_unchecked()
-                .unwrap();
-            let data = fields.next().unwrap().value_as::<Vec<u8>>().unwrap();
+                .ok_or_else(malformed)?
+                .value_as::<Vector>()?
+                .unpack_unchecked()?;
+            let data = fields.next().ok_or_else(malformed)?.value_as::<Vec<u8>>()?;
 
-            Log::new(
+            let log = Log::new(
                 address.to_eth_address(),
                 topics
                     .into_iter()
                     .map(|value| {
-                        value
-                            .value_as::<move_core_types::u256::U256>()
-                            .unwrap()
+                        let topic = value
+                            .value_as::<move_core_types::u256::U256>()?
                             .to_le_bytes()
-                            .into()
+                            .into();
+                        Ok(topic)
                     })
-                    .collect(),
+                    .collect::<Result<Vec<B256>, PartialVMError>>()?,
                 data.into(),
             )
-            .unwrap()
+            .ok_or_else(|| {
+                PartialVMError::new(StatusCode::ABORT_TYPE_MISMATCH_ERROR)
+                    .with_message("Greater than 4 topics in EVM return value".into())
+            })?;
+            Ok(log)
         })
-        .collect();
+        .collect::<Result<Vec<Log>, PartialVMError>>()?;
 
-    assert!(
-        evm_result_fields.next().is_none(),
-        "There are only 3 field in EVM return value."
-    );
+    if evm_result_fields.next().is_some() {
+        return Err(PartialVMError::new(StatusCode::ABORT_TYPE_MISMATCH_ERROR)
+            .with_message("There are only 3 field in EVM return value.".into()));
+    }
 
-    EvmNativeOutcome {
+    Ok(EvmNativeOutcome {
         is_success,
         output,
         logs,
-    }
+    })
 }

--- a/execution/Cargo.toml
+++ b/execution/Cargo.toml
@@ -8,6 +8,9 @@ edition.workspace = true
 default = []
 test-doubles = []
 
+[lints]
+workspace = true
+
 [dependencies]
 alloy.workspace = true
 alloy-rlp.workspace = true

--- a/execution/src/canonical.rs
+++ b/execution/src/canonical.rs
@@ -291,7 +291,7 @@ pub(super) fn execute_canonical_transaction<
     });
 
     let (mut user_changes, mut extensions) = session.finish_with_extensions(&code_storage)?;
-    let evm_changes = umi_evm_ext::extract_evm_changes(&extensions);
+    let evm_changes = umi_evm_ext::extract_evm_changes(&extensions)?;
     let table_changes = crate::table_changes::extract_table_changes(
         &mut extensions,
         code_storage.module_storage(),

--- a/execution/src/deposited.rs
+++ b/execution/src/deposited.rs
@@ -100,7 +100,7 @@ pub(super) fn execute_deposited_transaction<
         )
         .map_err(Error::from)
         .and_then(|values| {
-            let evm_outcome = extract_evm_result(values);
+            let evm_outcome = extract_evm_result(values)?;
             if !evm_outcome.is_success {
                 return Err(UserError::DepositFailure(evm_outcome.output).into());
             }
@@ -145,7 +145,7 @@ pub(super) fn execute_deposited_transaction<
     let mut logs = events.logs();
     logs.extend(evm_logs);
     let gas_used = total_gas_used(&gas_meter, input.genesis_config);
-    let evm_changes = extract_evm_changes(&extensions);
+    let evm_changes = extract_evm_changes(&extensions)?;
     changes
         .squash(evm_changes.accounts)
         .expect("EVM changes must merge with other session changes");

--- a/execution/src/deposited.rs
+++ b/execution/src/deposited.rs
@@ -8,6 +8,8 @@ use {
     alloy::primitives::U256,
     aptos_framework::natives::event::NativeEventContext,
     aptos_table_natives::TableResolver,
+    aptos_types::vm_status::StatusCode,
+    move_binary_format::errors::PartialVMError,
     move_core_types::language_storage::ModuleId,
     move_vm_runtime::{
         AsUnsyncCodeStorage,
@@ -63,12 +65,11 @@ pub(super) fn execute_deposited_transaction<
 
     let module = ModuleId::new(EVM_NATIVE_ADDRESS, EVM_NATIVE_MODULE.into());
     let function_name = EVM_DEPOSIT_FN_NAME;
-    // Unwraps in serialization are safe because the layouts match the types.
     let to_address = match input.tx.to {
         revm::primitives::TxKind::Call(addr) => addr.to_move_address(),
         _ => unimplemented!("Contract creation through deposit tx not yet supported"),
     };
-    let args: Vec<Vec<u8>> = [
+    let args: Result<Vec<Vec<u8>>, Error> = [
         (
             Value::address(input.tx.from.to_move_address()),
             &ADDRESS_LAYOUT,
@@ -82,23 +83,28 @@ pub(super) fn execute_deposited_transaction<
     ]
     .into_iter()
     .map(|(value, layout)| {
-        ValueSerDeContext::new()
-            .serialize(&value, layout)
-            .unwrap()
-            .unwrap()
+        Ok(ValueSerDeContext::new()
+            .serialize(&value, layout)?
+            .ok_or_else(|| {
+                PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR)
+                    .with_message("Failed to serialize EVM deposit args".into())
+            })?)
     })
     .collect();
-    let outcome = session
-        .execute_function_bypass_visibility(
-            &module,
-            function_name,
-            Vec::new(),
-            args,
-            &mut gas_meter,
-            &mut traversal_context,
-            &code_storage,
-        )
-        .map_err(Error::from)
+    let outcome = args
+        .and_then(|args| {
+            session
+                .execute_function_bypass_visibility(
+                    &module,
+                    function_name,
+                    Vec::new(),
+                    args,
+                    &mut gas_meter,
+                    &mut traversal_context,
+                    &code_storage,
+                )
+                .map_err(Error::from)
+        })
         .and_then(|values| {
             let evm_outcome = extract_evm_result(values)?;
             if !evm_outcome.is_success {
@@ -114,7 +120,7 @@ pub(super) fn execute_deposited_transaction<
             if mint_amount != 0 {
                 eth_token::mint_eth(
                     &EVM_NATIVE_ADDRESS,
-                    U256::from(input.tx.mint.unwrap()),
+                    U256::from(mint_amount),
                     &mut session,
                     &mut traversal_context,
                     &mut gas_meter,

--- a/execution/src/eth_token.rs
+++ b/execution/src/eth_token.rs
@@ -322,9 +322,9 @@ pub fn quick_get_eth_balance(
     account: &AccountAddress,
     state: &(impl MoveResolver + TableResolver),
     storage_trie: &impl StorageTrieRepository,
-) -> U256 {
+) -> Result<U256, umi_shared::error::Error> {
     let umi_vm = UmiVm::new(&Default::default());
-    let vm = umi_vm.create_move_vm().unwrap();
+    let vm = umi_vm.create_move_vm()?;
     let module_bytes_storage = ResolverBasedModuleBytesStorage::new(state);
     let code_storage = module_bytes_storage.as_unsync_code_storage(&umi_vm);
     // Noop block hash lookup is safe here because the EVM is not used for
@@ -341,7 +341,6 @@ pub fn quick_get_eth_balance(
         &mut gas_meter,
         &code_storage,
     )
-    .unwrap()
 }
 
 #[cfg(any(feature = "test-doubles", test))]

--- a/execution/src/execute.rs
+++ b/execution/src/execute.rs
@@ -164,7 +164,7 @@ pub(super) fn deploy_evm_contract<G: GasMeter, MS: ModuleStorage>(
         )
         .map_err(|e| User(UserError::Vm(e)))?;
 
-    let evm_outcome = extract_evm_result(outcome);
+    let evm_outcome = extract_evm_result(outcome)?;
 
     if !evm_outcome.is_success {
         return Err(User(UserError::EvmContractCreationFailure));
@@ -218,7 +218,7 @@ pub(super) fn execute_evm_contract<G: GasMeter, MS: ModuleStorage>(
         )
         .map_err(|e| User(UserError::Vm(e)))?;
 
-    let evm_outcome = extract_evm_result(outcome);
+    let evm_outcome = extract_evm_result(outcome)?;
 
     Ok(evm_outcome)
 }

--- a/execution/src/tests/utils.rs
+++ b/execution/src/tests/utils.rs
@@ -461,6 +461,7 @@ impl TestContext {
             self.state.resolver(),
             &self.evm_storage,
         )
+        .unwrap()
     }
 
     /// Gets the nonce for an address.

--- a/execution/src/tests/utils.rs
+++ b/execution/src/tests/utils.rs
@@ -529,7 +529,7 @@ impl TestContext {
             )
             .unwrap();
 
-        let outcome = extract_evm_result(outcome);
+        let outcome = extract_evm_result(outcome).unwrap();
         let (changes, extensions) = session.finish_with_extensions(&code_storage).unwrap();
         (outcome, changes, extensions)
     }
@@ -587,7 +587,7 @@ impl TestContext {
     ) -> EvmNativeOutcome {
         let (outcome, mut changes, extensions) = self.quick_call(args, module_name, fn_name);
 
-        let evm_changes = extract_evm_changes(&extensions);
+        let evm_changes = extract_evm_changes(&extensions).unwrap();
         changes.squash(evm_changes.accounts).unwrap();
         drop(extensions);
 

--- a/genesis-builder/Cargo.toml
+++ b/genesis-builder/Cargo.toml
@@ -4,6 +4,9 @@ description = "Generate genesis snapshots"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 alloy.workspace = true
 anyhow.workspace = true

--- a/genesis-builder/src/main.rs
+++ b/genesis-builder/src/main.rs
@@ -177,6 +177,10 @@ fn build_aptos_packages() -> anyhow::Result<()> {
     Ok(())
 }
 
+// Safety: this module is not part of the op-move production code.
+// It is only used a one-time setup for the pre-installed Move modules at genesis.
+// It is acceptable for this setup to panic if something is wrong with the local configuration.
+#[allow(clippy::unwrap_used)]
 fn fix_sui_packages() -> anyhow::Result<()> {
     // Addresses are mapped from 0x1, 0x2 to 0x21, 0x22 for conflict resolution
     let move_toml_file = &SUI_FRAMEWORK_DIR

--- a/genesis-image/Cargo.toml
+++ b/genesis-image/Cargo.toml
@@ -8,6 +8,9 @@ edition.workspace = true
 default = []
 test-doubles = []
 
+[lints]
+workspace = true
+
 [dependencies]
 bcs.workspace = true
 move-core-types.workspace = true

--- a/genesis-image/build.rs
+++ b/genesis-image/build.rs
@@ -19,6 +19,8 @@ fn main() {
     save(&vm, &genesis_config, &storage_trie);
 }
 
+// Safety: genesis-image is only used in tests
+#[allow(clippy::unwrap_used)]
 pub fn save(
     vm: &UmiVm,
     config: &GenesisConfig,

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -8,6 +8,9 @@ edition.workspace = true
 default = []
 test-doubles = []
 
+[lints]
+workspace = true
+
 [dependencies]
 alloy.workspace = true
 anyhow.workspace = true

--- a/genesis/src/bridged_tokens.rs
+++ b/genesis/src/bridged_tokens.rs
@@ -95,7 +95,7 @@ pub fn deploy_bridged_tokens(
             anyhow::bail!("Bridged token deployment failed: EVM outcome");
         }
     }
-    let new_changes = extract_evm_changes_from_native(&ctx);
+    let new_changes = extract_evm_changes_from_native(&ctx)?;
     l2_changes.accounts.squash(new_changes.accounts)?;
     for (address, trie_changes) in new_changes.storage {
         l2_changes.storage = l2_changes.storage.with_trie_changes(address, trie_changes);
@@ -239,7 +239,8 @@ fn test_deploy_bridged_tokens() {
     assert!(n_bridged_tokens > 0);
     let state = umi_state::InMemoryState::default();
     let storage = InMemoryStorageTrieRepository::new();
-    let l2_changes = crate::l2_contracts::init_state(config.l2_contract_genesis, &state, &storage);
+    let l2_changes =
+        crate::l2_contracts::init_state(config.l2_contract_genesis, &state, &storage).unwrap();
     let new_l2_changes = deploy_bridged_tokens(l2_changes.clone(), config.token_list).unwrap();
     let added_addresses = new_l2_changes
         .storage

--- a/genesis/src/config.rs
+++ b/genesis/src/config.rs
@@ -90,7 +90,7 @@ impl Default for GenesisConfig {
     fn default() -> Self {
         let path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
-            .unwrap()
+            .expect("Cargo manifest has a parent directory")
             .join("execution/src/tests/res/bridged_tokens_test.json");
         Self {
             chain_id: CHAIN_ID,

--- a/genesis/src/l2_contracts.rs
+++ b/genesis/src/l2_contracts.rs
@@ -1,6 +1,9 @@
 use {
     alloy::genesis::Genesis,
-    umi_evm_ext::{Changes, state::StorageTrieRepository},
+    umi_evm_ext::{
+        Changes,
+        state::{Error, StorageTrieRepository},
+    },
     umi_state::State,
 };
 
@@ -8,6 +11,6 @@ pub fn init_state(
     genesis: Genesis,
     state: &impl State,
     storage_trie: &impl StorageTrieRepository,
-) -> Changes {
+) -> Result<Changes, Error> {
     umi_evm_ext::genesis_state_changes(genesis, state.resolver(), storage_trie)
 }

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -34,7 +34,8 @@ pub fn build(
 
     // Deploy OP stack L2 contracts
     let mut changes_l2 =
-        l2_contracts::init_state(config.l2_contract_genesis.clone(), &state, storage_trie);
+        l2_contracts::init_state(config.l2_contract_genesis.clone(), &state, storage_trie)
+            .expect("L2 contracts must deploy");
 
     // Deploy additional bridged tokens (if any)
     if !config.token_list.is_empty() {

--- a/genesis/src/serde.rs
+++ b/genesis/src/serde.rs
@@ -59,10 +59,11 @@ impl From<SerdeChanges<Bytes, Bytes>> for ChangeSet {
         for (acc, changes) in value.accounts {
             for (id, op) in changes.modules {
                 set.add_module_op(ModuleId::new(acc, id), op.into())
-                    .unwrap();
+                    .expect("Duplicate IDs are impossible in a map");
             }
             for (id, op) in changes.resources {
-                set.add_resource_op(acc, id, op.into()).unwrap();
+                set.add_resource_op(acc, id, op.into())
+                    .expect("Duplicate IDs are impossible in a map");
             }
         }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,6 +10,9 @@ storage = ["storage-lmdb"]
 storage-lmdb = ["umi-storage-heed"]
 storage-rocksdb = ["umi-storage-rocksdb"]
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 aptos-types.workspace = true

--- a/server/benches/perf/main.rs
+++ b/server/benches/perf/main.rs
@@ -1,5 +1,7 @@
 use criterion::criterion_main;
 
+// Safety: this is benchmark code only, not used in production.
+#[allow(clippy::unwrap_used)]
 mod queue;
 
 criterion_main!(queue::benches);

--- a/server/benches/perf/queue/tests.rs
+++ b/server/benches/perf/queue/tests.rs
@@ -50,7 +50,7 @@ fn bench_build_1000_blocks_with_queue_size(bencher: &mut Criterion) -> impl Term
     {
         let (mut app, _reader) = initialize_app(Database::default(), &GenesisConfig::default());
 
-        app.genesis_update(input::GENESIS);
+        app.genesis_update(input::GENESIS).unwrap();
 
         build_1000_blocks(&current, &mut group, &mut app, buffer_size);
     }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -240,7 +240,8 @@ impl<'db, D: Dependencies<'db>> GenesisStateExt for Application<'db, D> {
         );
 
         let genesis_block = create_genesis_block(&self.block_hash, genesis_config);
-        self.genesis_update(genesis_block);
+        self.genesis_update(genesis_block)
+            .expect("Must add genesis block to state");
     }
 }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -11,7 +11,7 @@ async fn main() {
         .layer(EnvLayer::new())
         .layer(CliLayer::new())
         .try_build()
-        .unwrap();
+        .expect("Must build config to run app");
 
     umi_server::set_global_tracing_subscriber();
     umi_server::run(args).await;

--- a/server/src/tests/integration/erc20.rs
+++ b/server/src/tests/integration/erc20.rs
@@ -242,7 +242,7 @@ pub async fn l2_erc20_balance_of(token: Address, account: Address, rpc_url: &str
             EVM_NATIVE_OUTCOME_LAYOUT.clone(),
         )]),
     };
-    let evm_result = extract_evm_result(return_values);
+    let evm_result = extract_evm_result(return_values).unwrap();
 
     Ok(U256::from_be_slice(&evm_result.output))
 }
@@ -287,7 +287,7 @@ pub async fn l2_erc20_allowance(
             EVM_NATIVE_OUTCOME_LAYOUT.clone(),
         )]),
     };
-    let evm_result = extract_evm_result(return_values);
+    let evm_result = extract_evm_result(return_values).unwrap();
 
     Ok(U256::from_be_slice(&evm_result.output))
 }

--- a/server/src/tests/test_context.rs
+++ b/server/src/tests/test_context.rs
@@ -43,7 +43,7 @@ impl TestContext<'static> {
         let genesis_block = create_test_genesis_block(&app.block_hash, &genesis_config);
         let head = genesis_block.hash;
         let timestamp = genesis_block.block.header.timestamp;
-        app.genesis_update(genesis_block);
+        app.genesis_update(genesis_block).unwrap();
 
         let (queue, state) = umi_app::create(&mut app, 10);
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -8,6 +8,9 @@ edition.workspace = true
 default = []
 test-doubles = []
 
+[lints]
+workspace = true
+
 [dependencies]
 alloy.workspace = true
 bcs.workspace = true

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -8,6 +8,9 @@ edition.workspace = true
 default = []
 test-doubles = []
 
+[lints]
+workspace = true
+
 [dependencies]
 alloy.workspace = true
 aptos-table-natives.workspace = true

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -156,7 +156,10 @@ impl ToTreeValues for Changes {
                         let key = if let Some(address) = evm_key_address(k) {
                             TreeKey::Evm(address)
                         } else {
-                            TreeKey::StateKey(StateKey::resource(address, k).unwrap())
+                            TreeKey::StateKey(
+                                StateKey::resource(address, k)
+                                    .expect("Creating a resource state key is infallible"),
+                            )
                         };
 
                         (key, value)

--- a/storage/heed/Cargo.toml
+++ b/storage/heed/Cargo.toml
@@ -4,6 +4,9 @@ description = "Umi node integration with LMDB persistent storage engine via Heed
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 eth_trie.workspace = true
 heed.workspace = true

--- a/storage/rocksdb/Cargo.toml
+++ b/storage/rocksdb/Cargo.toml
@@ -4,6 +4,9 @@ description = "Umi node integration with RocksDB persistent storage engine"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 eth_trie.workspace = true
 move-binary-format.workspace = true

--- a/storage/rocksdb/src/block.rs
+++ b/storage/rocksdb/src/block.rs
@@ -58,7 +58,7 @@ impl BlockRepository for RocksDbBlockRepository<'_> {
             .iterator_cf(&height_cf(db), IteratorMode::End)
             .next()
             .transpose()?
-            .map(|(_, hash)| self.by_hash(db, B256::new(hash.as_ref().try_into().unwrap())))
+            .map(|(_, hash)| self.by_hash(db, B256::from_slice(hash.as_ref())))
             .transpose()?
             .flatten())
     }
@@ -121,7 +121,7 @@ impl BlockQueries for RocksDbBlockQueries {
         include_transactions: bool,
     ) -> Result<Option<BlockResponse>, Self::Err> {
         db.get_pinned_cf(&height_cf(db), height.to_key())?
-            .map(|hash| B256::new(hash.as_ref().try_into().unwrap()))
+            .map(|hash| B256::from_slice(hash.as_ref()))
             .map(|hash| self.by_hash(db, hash, include_transactions))
             .unwrap_or(Ok(None))
     }
@@ -135,12 +135,12 @@ impl BlockQueries for RocksDbBlockQueries {
     }
 }
 
-pub(crate) fn block_cf(db: &RocksDb) -> impl AsColumnFamilyRef + use<'_> {
+pub(crate) fn block_cf(db: &RocksDb) -> impl AsColumnFamilyRef {
     db.cf_handle(BLOCK_COLUMN_FAMILY)
         .expect("Column family should exist")
 }
 
-fn height_cf(db: &RocksDb) -> impl AsColumnFamilyRef + use<'_> {
+fn height_cf(db: &RocksDb) -> impl AsColumnFamilyRef {
     db.cf_handle(HEIGHT_COLUMN_FAMILY)
         .expect("Column family should exist")
 }

--- a/storage/rocksdb/src/evm_storage_trie.rs
+++ b/storage/rocksdb/src/evm_storage_trie.rs
@@ -41,7 +41,7 @@ impl DbWithRoot for RocksEthStorageTrieDb {
         Ok(self
             .db
             .get_cf(self.root_cf(), self.account.as_slice())?
-            .map(|v| B256::new(v.try_into().unwrap())))
+            .map(|v| B256::from_slice(&v)))
     }
 
     fn put_root(&self, root: B256) -> Result<(), rocksdb::Error> {

--- a/storage/rocksdb/src/generic.rs
+++ b/storage/rocksdb/src/generic.rs
@@ -33,7 +33,11 @@ macro_rules! int_impl {
         }
         impl<'de> FromKey<'de> for $int {
             fn from_key(slice: &'de [u8]) -> Self {
-                $int::from_be_bytes(slice.try_into().unwrap())
+                $int::from_be_bytes(
+                    slice
+                        .try_into()
+                        .expect("Can convert bytes representation of an integer key back into an integer")
+                )
             }
         }
     };
@@ -43,7 +47,7 @@ int_impl!(u64);
 
 impl<T: serde::Serialize> ToValue for T {
     fn to_value(&self) -> Vec<u8> {
-        serde_json::to_vec(self).unwrap()
+        serde_json::to_vec(self).expect("Must serialize values to bytes for writing to RocksDB")
     }
 }
 

--- a/storage/rocksdb/src/payload.rs
+++ b/storage/rocksdb/src/payload.rs
@@ -83,7 +83,7 @@ impl PayloadQueries for RocksDbPayloadQueries {
         let Some(slice) = db.get_pinned_cf(&cf(db), id.to_key())? else {
             return Ok(MaybePayloadResponse::Unknown);
         };
-        let hash = B256::new(slice.as_ref().try_into().unwrap());
+        let hash = B256::from_slice(slice.as_ref());
         let response = self
             .by_hash(db, hash)?
             .map_or(MaybePayloadResponse::Unknown, MaybePayloadResponse::Some);

--- a/storage/rocksdb/src/state.rs
+++ b/storage/rocksdb/src/state.rs
@@ -31,7 +31,7 @@ impl HeightToStateRootIndex for RocksDbStateRootIndex {
         Ok(self
             .db
             .get_pinned_cf(&self.cf(), height.to_key())?
-            .map(|v| B256::new(v.as_ref().try_into().unwrap())))
+            .map(|v| B256::from_slice(v.as_ref())))
     }
 
     fn height(&self) -> Result<u64, Self::Err> {

--- a/storage/rocksdb/src/trie.rs
+++ b/storage/rocksdb/src/trie.rs
@@ -37,7 +37,7 @@ impl DbWithRoot for RocksEthTrieDb {
         Ok(self
             .db
             .get_cf(self.root_cf(), ROOT_KEY)?
-            .map(|v| B256::new(v.try_into().unwrap())))
+            .map(|v| B256::from_slice(&v)))
     }
 
     fn put_root(&self, root: B256) -> Result<(), rocksdb::Error> {

--- a/storage/rocksdb/tests/common.rs
+++ b/storage/rocksdb/tests/common.rs
@@ -6,7 +6,7 @@ pub fn create_db() -> rocksdb::DB {
         env!("CARGO_CRATE_NAME")
     );
 
-    if std::fs::exists(path).unwrap() {
+    if std::fs::exists(path).unwrap_or(false) {
         std::fs::remove_dir_all(path)
             .expect("Removing non-empty database directory should succeed");
     }

--- a/trie/Cargo.toml
+++ b/trie/Cargo.toml
@@ -4,6 +4,9 @@ description = "Ethereum trie extensions"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 eth_trie.workspace = true
 umi-shared.workspace = true


### PR DESCRIPTION
### Description
Works towards #203 by checking all `unwrap` usages. Most are replaced with error propogation, some are replaced by `expect` calls with a description of why it should never panic. Any new `unwrap`s in the diff occur in tests where a function now returns a `Result` where is did  not before.

### Changes
- Remove/replace `unwrap` calls (refactor only).

### Testing
- Existing tests.

### Notes
- Usages of `unwrap` found via `cargo clippy -- -Dclippy::unwrap_used`
- Reviewing this PR may be easier if done commit by commit instead of all at once.