### PR TITLE
feat(api): `eth_gasPrice`, `eth_maxPriorityFeePerGas` endpoints

### DIFF
--- a/api/src/method_name.rs
+++ b/api/src/method_name.rs
@@ -19,6 +19,7 @@ pub enum MethodName {
     TransactionReceipt,
     GetProof,
     GasPrice,
+    MaxPriorityFeePerGas,
 }
 
 impl MethodName {
@@ -56,6 +57,7 @@ impl FromStr for MethodName {
             "eth_getTransactionReceipt" => Self::TransactionReceipt,
             "eth_getProof" => Self::GetProof,
             "eth_gasPrice" => Self::GasPrice,
+            "eth_maxPriorityFeePerGas" => Self::MaxPriorityFeePerGas,
             other => {
                 return Err(JsonRpcError::invalid_method(other));
             }

--- a/api/src/methods/block_number.rs
+++ b/api/src/methods/block_number.rs
@@ -3,16 +3,14 @@ use {
     umi_app::{ApplicationReader, Dependencies},
 };
 
-pub async fn execute<'app>(
+pub async fn execute<'reader>(
     request: serde_json::Value,
-    app: &ApplicationReader<'app, impl Dependencies<'app>>,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
     parse_params_0(request)?;
-    // this is a generic server error code
     let response = app.block_number()?;
 
-    // Format the block number as a hex string
-    Ok(serde_json::to_value(format!("0x{:x}", response))
+    Ok(serde_json::to_value(format!("{response:#x}"))
         .expect("Must be able to JSON-serialize response"))
 }
 

--- a/api/src/methods/chain_id.rs
+++ b/api/src/methods/chain_id.rs
@@ -1,12 +1,15 @@
 use {
-    crate::jsonrpc::JsonRpcError,
+    crate::{json_utils::parse_params_0, jsonrpc::JsonRpcError},
     umi_app::{ApplicationReader, Dependencies},
 };
 
 pub async fn execute<'reader>(
+    request: serde_json::Value,
     app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
 ) -> Result<serde_json::Value, JsonRpcError> {
+    parse_params_0(request)?;
     let response = app.chain_id();
+
     Ok(serde_json::to_value(format!("{response:#x}"))
         .expect("Must be able to JSON-serialize response"))
 }
@@ -19,8 +22,15 @@ mod tests {
     async fn test_execute() {
         let (reader, _app) = create_app();
 
+        let request: serde_json::Value = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_chainId",
+            "params": [],
+            "id": 1
+        });
+
         let expected_response: serde_json::Value = serde_json::from_str(r#""0x194""#).unwrap();
-        let actual_response = execute(&reader).await.unwrap();
+        let actual_response = execute(request, &reader).await.unwrap();
 
         assert_eq!(actual_response, expected_response);
     }

--- a/api/src/methods/gas_price.rs
+++ b/api/src/methods/gas_price.rs
@@ -1,18 +1,39 @@
-use crate::jsonrpc::JsonRpcError;
+use umi_app::{ApplicationReader, Dependencies};
 
-pub async fn execute() -> Result<serde_json::Value, JsonRpcError> {
-    Ok(serde_json::to_value("0x3b9aca00").expect("Must be able to JSON-serialize response"))
+use crate::{json_utils::parse_params_0, jsonrpc::JsonRpcError};
+
+pub async fn execute<'reader>(
+    request: serde_json::Value,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
+) -> Result<serde_json::Value, JsonRpcError> {
+    parse_params_0(request)?;
+
+    let response = app.gas_price()?;
+
+    Ok(serde_json::to_value(format!("{response:#x}"))
+        .expect("Must be able to JSON-serialize response"))
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::methods::tests::create_app;
+
     use super::*;
 
     #[tokio::test]
     async fn test_execute() {
-        // TODO: Return the actual gas price, currently hardcoded to 1,000,000,000
+        let (reader, _app) = create_app();
+
+        let request: serde_json::Value = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_gasPrice",
+            "params": [],
+            "id": 1
+        });
+
         let expected_response: serde_json::Value = serde_json::from_str(r#""0x3b9aca00""#).unwrap();
-        let response = execute().await.unwrap();
+        let response = execute(request, &reader).await.unwrap();
+
         assert_eq!(response, expected_response);
     }
 }

--- a/api/src/methods/max_priority_fee_per_gas.rs
+++ b/api/src/methods/max_priority_fee_per_gas.rs
@@ -1,0 +1,39 @@
+use umi_app::{ApplicationReader, Dependencies};
+
+use crate::{json_utils::parse_params_0, jsonrpc::JsonRpcError};
+
+pub async fn execute<'reader>(
+    request: serde_json::Value,
+    app: &ApplicationReader<'reader, impl Dependencies<'reader>>,
+) -> Result<serde_json::Value, JsonRpcError> {
+    parse_params_0(request)?;
+
+    let response = app.max_priority_fee_per_gas()?;
+
+    Ok(serde_json::to_value(format!("{response:#x}"))
+        .expect("Must be able to JSON-serialize response"))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::methods::tests::create_app;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_execute() {
+        let (reader, _app) = create_app();
+
+        let request: serde_json::Value = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_maxPriorityFeePerGas",
+            "params": [],
+            "id": 1
+        });
+
+        let expected_response: serde_json::Value = serde_json::from_str(r#""0x3b9aca00""#).unwrap();
+        let response = execute(request, &reader).await.unwrap();
+
+        assert_eq!(response, expected_response);
+    }
+}

--- a/api/src/methods/max_priority_fee_per_gas.rs
+++ b/api/src/methods/max_priority_fee_per_gas.rs
@@ -31,9 +31,31 @@ mod tests {
             "id": 1
         });
 
-        let expected_response: serde_json::Value = serde_json::from_str(r#""0x3b9aca00""#).unwrap();
+        let expected_response: serde_json::Value = serde_json::from_str(r#""0xf4240""#).unwrap();
         let response = execute(request, &reader).await.unwrap();
 
         assert_eq!(response, expected_response);
+
+        let hex_str = response.as_str().unwrap().strip_prefix("0x").unwrap();
+        // The value is the minimum suggested fee constant without base fee
+        assert_eq!(u64::from_str_radix(hex_str, 16).unwrap(), 1_000_000);
+    }
+
+    #[tokio::test]
+    async fn test_bad_input() {
+        let (reader, _app) = create_app();
+
+        let request: serde_json::Value = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_maxPriorityFeePerGas",
+            "params": ["wrong"],
+            "id": 1
+        });
+
+        let response = execute(request.clone(), &reader).await;
+        assert_eq!(
+            response.unwrap_err(),
+            JsonRpcError::too_many_params_error(request)
+        );
     }
 }

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -13,6 +13,7 @@ pub mod get_payload;
 pub mod get_proof;
 pub mod get_transaction_by_hash;
 pub mod get_transaction_receipt;
+pub mod max_priority_fee_per_gas;
 pub mod new_payload;
 pub mod send_raw_transaction;
 

--- a/api/src/request.rs
+++ b/api/src/request.rs
@@ -58,7 +58,7 @@ async fn inner_handle_request<'reader>(
         GetPayloadV3 => get_payload::execute_v3(request, app).await,
         NewPayloadV3 => new_payload::execute_v3(request, app).await,
         SendRawTransaction => send_raw_transaction::execute(request, queue).await,
-        ChainId => chain_id::execute(app).await,
+        ChainId => chain_id::execute(request, app).await,
         GetBalance => get_balance::execute(request, app).await,
         GetNonce => get_nonce::execute(request, app).await,
         GetTransactionByHash => get_transaction_by_hash::execute(request, app).await,
@@ -70,6 +70,6 @@ async fn inner_handle_request<'reader>(
         Call => call::execute(request, app).await,
         TransactionReceipt => get_transaction_receipt::execute(request, app).await,
         GetProof => get_proof::execute(request, app).await,
-        GasPrice => gas_price::execute().await,
+        GasPrice => gas_price::execute(request, app).await,
     }
 }

--- a/api/src/request.rs
+++ b/api/src/request.rs
@@ -71,5 +71,6 @@ async fn inner_handle_request<'reader>(
         TransactionReceipt => get_transaction_receipt::execute(request, app).await,
         GetProof => get_proof::execute(request, app).await,
         GasPrice => gas_price::execute(request, app).await,
+        MaxPriorityFeePerGas => max_priority_fee_per_gas::execute(request, app).await,
     }
 }

--- a/app/src/query.rs
+++ b/app/src/query.rs
@@ -23,8 +23,8 @@ use {
 };
 
 const MAX_PERCENTILE_COUNT: usize = 100;
-const MIN_SUGGESTED_PRIORITY_FEE: u128 = 1_000_000;
-const MAX_SUGGESTED_PRIORITY_FEE: u128 = 500_000_000_000;
+pub(crate) const MIN_SUGGESTED_PRIORITY_FEE: u128 = 1_000_000;
+pub(crate) const MAX_SUGGESTED_PRIORITY_FEE: u128 = 500_000_000_000;
 
 #[derive(Debug)]
 enum BlockNumberOrHash {

--- a/app/src/query.rs
+++ b/app/src/query.rs
@@ -252,6 +252,13 @@ impl<'app, D: Dependencies<'app>> ApplicationReader<'app, D> {
         Ok(suggestion + block_base_fee as u128)
     }
 
+    pub fn max_priority_fee_per_gas(&self) -> Result<u128> {
+        let (_, suggestion) = self.estimate_priority_fee()?;
+        // virtually the same as `eth_gasPrice` but for dynamic fee transactions, and doesn't
+        // add back the base fee
+        Ok(suggestion)
+    }
+
     pub fn transaction_receipt(&self, tx_hash: B256) -> Result<Option<TransactionReceipt>> {
         self.receipt_queries
             .by_transaction_hash(&self.receipt_memory, tx_hash)

--- a/app/src/query.rs
+++ b/app/src/query.rs
@@ -1,7 +1,7 @@
 use {
     crate::{ApplicationReader, Dependencies},
     alloy::{
-        consensus::Header,
+        consensus::{Header, Transaction},
         eips::{
             BlockId,
             BlockNumberOrTag::{self, Earliest, Finalized, Latest, Number, Pending, Safe},
@@ -23,6 +23,8 @@ use {
 };
 
 const MAX_PERCENTILE_COUNT: usize = 100;
+const MIN_SUGGESTED_PRIORITY_FEE: u128 = 1_000_000;
+const MAX_SUGGESTED_PRIORITY_FEE: u128 = 500_000_000_000;
 
 #[derive(Debug)]
 enum BlockNumberOrHash {
@@ -244,6 +246,12 @@ impl<'app, D: Dependencies<'app>> ApplicationReader<'app, D> {
         )
     }
 
+    pub fn gas_price(&self) -> Result<u128> {
+        let (block_base_fee, suggestion) = self.estimate_priority_fee()?;
+        // legacy `eth_gasPrice` call includes base fee for block
+        Ok(suggestion + block_base_fee as u128)
+    }
+
     pub fn transaction_receipt(&self, tx_hash: B256) -> Result<Option<TransactionReceipt>> {
         self.receipt_queries
             .by_transaction_hash(&self.receipt_memory, tx_hash)
@@ -391,5 +399,55 @@ impl<'app, D: Dependencies<'app>> ApplicationReader<'app, D> {
 
         acc_total_reward(total_reward, block_gas_used, &price_and_cum_gas);
         Ok(parent_hash)
+    }
+
+    fn estimate_priority_fee(&self) -> Result<(u64, u128)> {
+        let latest_block = self.block_by_height(BlockNumberOrTag::Latest, true)?;
+        let Header {
+            gas_limit: block_gas_limit,
+            gas_used: block_gas_used,
+            base_fee_per_gas: block_base_fee,
+            ..
+        } = latest_block.0.header.inner;
+
+        let max_tx_gas_used = latest_block
+            .0
+            .transactions
+            .hashes()
+            .map(|hash| {
+                self.transaction_receipt(hash)
+                    .expect("Database should work")
+                    .expect("Tx receipt should exist")
+                    .inner
+                    .gas_used
+            })
+            .max()
+            .unwrap_or_default();
+
+        let mut suggestion = 0;
+        // Using the same heuristic as `op-geth` does, only doing some actual calculations if the
+        // block is nearing congestion. While we could have a precise calculation due to having
+        // direct access to mempool, unlike what OP is assuming, this is still good enough as it
+        // doesn't get too involved.
+        if block_gas_used + max_tx_gas_used > block_gas_limit {
+            let mut tx_tips = latest_block
+                .0
+                .transactions
+                .into_transactions()
+                .map(|tx| {
+                    tx.inner
+                        .inner
+                        .effective_tip_per_gas(block_base_fee.unwrap_or_default())
+                        .unwrap_or_default()
+                })
+                .collect::<Vec<_>>();
+            tx_tips.sort();
+            let median_tip = tx_tips[tx_tips.len() / 2];
+            suggestion = median_tip + (median_tip / 10);
+        }
+        Ok((
+            block_base_fee.unwrap_or_default(),
+            suggestion.clamp(MIN_SUGGESTED_PRIORITY_FEE, MAX_SUGGESTED_PRIORITY_FEE),
+        ))
     }
 }

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -1,6 +1,9 @@
 use {
     super::*,
-    crate::{Payload, PayloadForExecution, TestDependencies},
+    crate::{
+        Payload, PayloadForExecution, TestDependencies,
+        query::{MAX_SUGGESTED_PRIORITY_FEE, MIN_SUGGESTED_PRIORITY_FEE},
+    },
     alloy::{
         consensus::{SignableTransaction, TxEip1559, TxEnvelope},
         eips::BlockNumberOrTag::{self, *},
@@ -191,6 +194,7 @@ fn mint_eth(
 fn create_app_with_fake_queries(
     addr: AccountAddress,
     initial_balance: U256,
+    base_fee: u64,
     height: u64,
 ) -> (
     ApplicationReader<'static, TestDependencies>,
@@ -201,7 +205,8 @@ fn create_app_with_fake_queries(
     let head_hash = B256::new(hex!(
         "e56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d"
     ));
-    let genesis_block = Block::default().with_hash(head_hash).with_value(U256::ZERO);
+    let mut genesis_block = Block::default().with_hash(head_hash).with_value(U256::ZERO);
+    genesis_block.block.header.base_fee_per_gas = Some(base_fee);
 
     let (memory_reader, mut memory) = shared_memory::new();
     let mut block_hash_cache =
@@ -441,7 +446,7 @@ fn test_fetched_balances_are_updated_after_transfer_of_funds() {
     let initial_balance = U256::from(5);
     let amount = U256::from(4);
     let (reader, mut app) =
-        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), initial_balance, 0);
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), initial_balance, 0, 0);
 
     let tx = create_transaction(0);
 
@@ -467,7 +472,7 @@ fn test_fetched_nonces_are_updated_after_executing_transaction() {
     let to = Address::new(hex!("44223344556677889900ffeeaabbccddee111111"));
     let initial_balance = U256::from(5);
     let (reader, mut app) =
-        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), initial_balance, 0);
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), initial_balance, 0, 0);
 
     let tx = create_transaction(0);
 
@@ -492,7 +497,7 @@ fn test_fetched_nonces_are_updated_after_executing_transaction() {
 fn test_one_payload_can_be_fetched_repeatedly() {
     let initial_balance = U256::from(5);
     let (reader, mut app) =
-        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), initial_balance, 0);
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), initial_balance, 0, 0);
 
     let tx = create_transaction(0);
 
@@ -512,7 +517,7 @@ fn test_one_payload_can_be_fetched_repeatedly() {
 fn test_older_payload_can_be_fetched_again_successfully() {
     let initial_balance = U256::from(15);
     let (reader, mut app) =
-        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), initial_balance, 0);
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), initial_balance, 0, 0);
 
     let tx = create_transaction(0);
 
@@ -561,7 +566,7 @@ fn test_older_payload_can_be_fetched_again_successfully() {
 fn test_txs_from_one_account_have_proper_nonce_ordering() {
     let initial_balance = U256::from(1000);
     let (reader, mut app) =
-        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), initial_balance, 0);
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), initial_balance, 0, 0);
 
     let mut tx_hashes: Vec<B256> = Vec::with_capacity(10);
 
@@ -631,7 +636,7 @@ fn test_fee_history_validation(
     percentiles: Option<Vec<f64>>,
 ) -> Result<FeeHistory, Error> {
     let (reader, _app) =
-        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10), 1);
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10), 0, 1);
 
     reader.fee_history(block_count, Latest, percentiles)
 }
@@ -648,7 +653,7 @@ fn test_fee_history_block_ranges(
     expected_oldest: u64,
 ) {
     let (reader, _app) =
-        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10), 5);
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10), 0, 5);
 
     let result = reader.fee_history(block_count, block_tag, None);
     assert!(result.is_ok());
@@ -663,7 +668,7 @@ fn test_fee_history_block_ranges(
 #[test_case(Some(vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0]), 9; "many percentiles")]
 fn test_fee_history_reward_lengths(percentiles: Option<Vec<f64>>, expected_reward_length: usize) {
     let (reader, _app) =
-        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10), 1);
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10), 0, 1);
 
     let result = reader.fee_history(1, Latest, percentiles);
     assert!(result.is_ok());
@@ -682,7 +687,7 @@ fn test_fee_history_reward_lengths(percentiles: Option<Vec<f64>>, expected_rewar
 #[test]
 fn test_fee_history_eip1559_fields() {
     let (reader, mut app) =
-        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10), 1);
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10), 0, 1);
 
     app.start_block_build(PayloadForExecution::default(), U64::from(1));
 
@@ -706,7 +711,7 @@ fn test_fee_history_eip1559_fields() {
 #[test_case(5, false; "blocks with transactions have non-zero gas ratio")]
 fn test_fee_history_empty_vs_full_blocks(num_txs: usize, expect_zero_ratio: bool) {
     let (reader, mut app) =
-        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(1000), 0);
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(1000), 0, 0);
 
     for i in 0..num_txs {
         let tx = create_transaction(i as u64);
@@ -741,7 +746,7 @@ fn test_fee_history_percentile_calculations(
     expected_rewards: Vec<u128>,
 ) {
     let (reader, mut app) =
-        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10000000), 0);
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10000000), 0, 0);
 
     for (i, (&gas_price, &gas_limit)) in gas_prices.iter().zip(gas_limits.iter()).enumerate() {
         let tx = create_transaction_with_max_fee_and_gas_limit(i as u64, gas_price, gas_limit);
@@ -775,7 +780,7 @@ fn test_fee_history_percentile_calculations(
 #[test_case(vec![2, 2, 2], false; "constant transactions")]
 fn test_fee_history_gas_ratio_progression(tx_counts: Vec<usize>, expect_increasing: bool) {
     let (reader, mut app) =
-        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10000000), 0);
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10000000), 0, 0);
 
     let mut nonce = 0;
     // Reasonable amount to allow a tx succeed
@@ -820,7 +825,7 @@ fn test_fee_history_gas_ratio_progression(tx_counts: Vec<usize>, expect_increasi
 #[test]
 fn test_fee_history_boundary_percentiles() {
     let (reader, mut app) =
-        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10000000), 0);
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10000000), 0, 0);
 
     // Create exactly 4 transactions with equal gas usage but different prices for boundary testing
     let gas_prices = [1_000_000_000, 2_000_000_000, 3_000_000_000, 4_000_000_000];
@@ -855,4 +860,129 @@ fn test_fee_history_boundary_percentiles() {
         assert_eq!(block_rewards[2], 1_500_000_000); // 66th percentile
         assert_eq!(block_rewards[3], 2_000_000_000); // 100th percentile
     }
+}
+
+#[test]
+fn test_max_priority_fee_low_congestion() {
+    let (reader, mut app) =
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10000000), 1, 0);
+
+    // Most likely to actually consume less than this preset tx gas limit
+    for i in 0..10 {
+        let tx = create_transaction_with_max_fee_and_gas_limit(i, 2_000_000_000, 40_000);
+        app.add_transaction(tx);
+    }
+
+    app.start_block_build(
+        Payload {
+            gas_limit: U64::from(1_000_000), // still well within the block limits
+            ..Default::default()
+        }
+        .try_into()
+        .unwrap(),
+        U64::from(1),
+    );
+
+    let max_priority_fee = reader.max_priority_fee_per_gas().unwrap();
+
+    // In low congestion, should return minimum priority fee
+    assert_eq!(max_priority_fee, MIN_SUGGESTED_PRIORITY_FEE);
+}
+
+#[test]
+fn test_max_priority_fee_high_congestion() {
+    let (reader, mut app) =
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10000000), 1, 0);
+
+    // Low preset gas limit actually makes txs run out of gas, but they still get receipts and
+    // block inclusion, and allows us to control actual gas consumed.
+    for i in 0..5 {
+        let tx = create_transaction_with_max_fee_and_gas_limit(
+            i,
+            2_000_000_000 + (i * 100_000_000) as u128,
+            20_000,
+        );
+        app.add_transaction(tx);
+    }
+
+    app.start_block_build(
+        Payload {
+            gas_limit: U64::from(100_000),
+            ..Default::default()
+        }
+        .try_into()
+        .unwrap(),
+        U64::from(1),
+    );
+
+    let max_priority_fee = reader.max_priority_fee_per_gas().unwrap();
+
+    assert!(max_priority_fee > MIN_SUGGESTED_PRIORITY_FEE);
+
+    // With 5 transactions, median is the 3rd. Expected tip for 3rd transaction:
+    // (2_000_000_000 + 2 * 100_000_000) / 2 = 1_100_000_000 (Division due to max
+    // priority fee set to half max fee at init). That value gets bumped by 10% additionally.
+    let expected_priority_fee = 1_210_000_000;
+    assert_eq!(max_priority_fee, expected_priority_fee);
+}
+
+#[test]
+fn test_gas_price_high_max_fee() {
+    let (reader, mut app) =
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10000000), 1, 0);
+
+    // Same setup as before, but with very high constant max fees instead of gradually increasing
+    // moderate ones
+    for i in 0..5 {
+        let tx = create_transaction_with_max_fee_and_gas_limit(i, 1_000_000_000_000, 21_000);
+        app.add_transaction(tx);
+    }
+
+    app.start_block_build(
+        Payload {
+            gas_limit: U64::from(100_000),
+            ..Default::default()
+        }
+        .try_into()
+        .unwrap(),
+        U64::from(1),
+    );
+
+    let max_priority_fee = reader.max_priority_fee_per_gas().unwrap();
+
+    // Should be clamped to maximum as 1e12 > 5e11
+    assert_eq!(max_priority_fee, MAX_SUGGESTED_PRIORITY_FEE);
+}
+
+#[test]
+fn test_gas_price_vs_max_priority_fee_difference() {
+    let (reader, mut app) =
+        create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10000000), 1, 0);
+
+    for i in 0..10 {
+        let tx = create_transaction_with_max_fee_and_gas_limit(i, 2_000_000_000, 40_000);
+        app.add_transaction(tx);
+    }
+
+    app.start_block_build(
+        Payload {
+            gas_limit: U64::from(1_000_000),
+            ..Default::default()
+        }
+        .try_into()
+        .unwrap(),
+        U64::from(1),
+    );
+
+    let gas_price = reader.gas_price().unwrap();
+    let max_priority_fee = reader.max_priority_fee_per_gas().unwrap();
+
+    // `eth_gasPrice` and `eth_maxPriorityFeePerGas` differ exactly by base fee
+    let difference = gas_price - max_priority_fee;
+    assert!(difference > 0);
+
+    let block = reader.block_by_height(Latest, true).unwrap();
+    let actual_base_fee = block.0.header.inner.base_fee_per_gas.unwrap_or_default();
+
+    assert_eq!(difference, actual_base_fee as u128);
 }


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
Adds actual logic for `eth_gasPrice` instead of a placeholder and introduces another gas fee prediction endpoint that's part of the current Ethereum RPC spec.
<!-- Fixes #123 -->
Closes #267.

### Changes
<!-- Key changes -->
- Unified 0 parameter handling in API crate
- The actual gas price algorithm in `app/src/query.rs`
- A new endpoint for `eth_maxPriorityFeePerGas` method that's not legacy and is functionally same, except the non-addition of base fee to the end result
- New tests

### Testing
<!-- How was it tested? -->
- [x] new API tests
- [x] new tests in `app/src/tests.rs`

### Notes
<!-- Additional info -->
Following `op-geth` example, we chose the newer simplified algorithm introduced by Optimism, that assumes a single builder, instead of the default `geth` one that's relying on gas price oracles and is closer in complexity to fee history calculation.  