### PR TITLE
chore(api): return block size in RPC responses

### DIFF
--- a/api/src/methods/get_block_by_hash.rs
+++ b/api/src/methods/get_block_by_hash.rs
@@ -60,6 +60,7 @@ mod tests {
             "extraData": "0x",
             "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "nonce": "0x0000000000000000",
+            "size": "0x1f0",
             "uncles": [],
             "transactions": [],
             "withdrawals": []

--- a/api/src/methods/get_block_by_number.rs
+++ b/api/src/methods/get_block_by_number.rs
@@ -71,6 +71,7 @@ mod tests {
             "extraData": "0x",
             "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "nonce": "0x0000000000000000",
+            "size": "0x1f0",
             "uncles": [],
             "transactions": [],
             "withdrawals": []

--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -89,7 +89,9 @@ mod tests {
         let head_hash = B256::new(hex!(
             "e56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d"
         ));
-        let genesis_block = Block::default().with_hash(head_hash).with_value(U256::ZERO);
+        let genesis_block = Block::default()
+            .into_extended_with_hash(head_hash)
+            .with_value(U256::ZERO);
 
         let (memory_reader, mut memory) = shared_memory::new();
         let mut block_hash_cache =

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -74,8 +74,11 @@ pub mod tests {
             ..Default::default()
         };
         let genesis_block = Block::new(genesis_header, Vec::new())
-            .with_hash(head_hash)
+            .into_extended_with_hash(head_hash)
             .with_value(U256::ZERO);
+
+        let size = genesis_block.byte_length(Vec::new());
+        let genesis_block = genesis_block.with_size(size);
 
         let (memory_reader, mut memory) = shared_memory::new();
         let mut block_hash_cache =

--- a/api/src/methods/new_payload.rs
+++ b/api/src/methods/new_payload.rs
@@ -255,7 +255,9 @@ mod tests {
         let head_hash = B256::new(hex!(
             "781f09c5b7629a7ca30668e440ea40557f01461ad6f105b371f61ff5824b2449"
         ));
-        let genesis_block = Block::default().with_hash(head_hash).with_value(U256::ZERO);
+        let genesis_block = Block::default()
+            .into_extended_with_hash(head_hash)
+            .with_value(U256::ZERO);
 
         let (memory_reader, mut memory) = shared_memory::new();
         let mut block_hash_cache =

--- a/app/src/block_hash.rs
+++ b/app/src/block_hash.rs
@@ -285,7 +285,8 @@ mod tests {
                 let hash = B256::from([(height % 256) as u8; 32]);
                 let header = Header::default();
                 let block = Block::new(header, Vec::new());
-                let extended_block = ExtendedBlock::new(hash, U256::ZERO, U64::ZERO, block);
+                let extended_block =
+                    ExtendedBlock::new(hash, U256::ZERO, U64::ZERO, U256::ZERO, block);
                 let response =
                     BlockResponse::from_block_with_transactions(extended_block, Vec::new());
                 Ok(Some(response))

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -81,7 +81,9 @@ fn create_app_with_given_queries<SQ: StateQueries + Clone + Send + Sync + 'stati
     let head_hash = B256::new(hex!(
         "e56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d"
     ));
-    let genesis_block = Block::default().with_hash(head_hash).with_value(U256::ZERO);
+    let genesis_block = Block::default()
+        .into_extended_with_hash(head_hash)
+        .with_value(U256::ZERO);
 
     let (memory_reader, mut memory) = shared_memory::new();
     let mut block_hash_cache =
@@ -205,7 +207,9 @@ fn create_app_with_fake_queries(
     let head_hash = B256::new(hex!(
         "e56ec7ba741931e8c55b7f654a6e56ed61cf8b8279bf5e3ef6ac86a11eb33a9d"
     ));
-    let mut genesis_block = Block::default().with_hash(head_hash).with_value(U256::ZERO);
+    let mut genesis_block = Block::default()
+        .into_extended_with_hash(head_hash)
+        .with_value(U256::ZERO);
     genesis_block.block.header.base_fee_per_gas = Some(base_fee);
 
     let (memory_reader, mut memory) = shared_memory::new();

--- a/blockchain/src/block/read.rs
+++ b/blockchain/src/block/read.rs
@@ -67,9 +67,9 @@ impl BlockResponse {
             header: alloy::rpc::types::Header {
                 hash: value.hash,
                 inner: value.block.header,
-                // TODO: review fields below
+                // Deprecated for PoS clients: <https://github.com/ethereum/execution-apis/pull/570>
                 total_difficulty: None,
-                size: None,
+                size: Some(value.size),
             },
             uncles: Vec::new(),
             withdrawals: Some(Withdrawals(Vec::new())),

--- a/server/benches/perf/queue/input.rs
+++ b/server/benches/perf/queue/input.rs
@@ -23,6 +23,7 @@ pub const GENESIS: ExtendedBlock = {
         )),
         value: U256::ZERO,
         payload_id: PayloadId::ZERO,
+        size: U256::ZERO,
         block: Block {
             header: Header {
                 parent_hash: B256::ZERO,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -302,7 +302,9 @@ fn create_genesis_block(
     let hash = block_hash.block_hash(&genesis_header);
     let genesis_block = Block::new(genesis_header, Vec::new());
 
-    genesis_block.with_hash(hash).with_value(U256::ZERO)
+    genesis_block
+        .into_extended_with_hash(hash)
+        .with_value(U256::ZERO)
 }
 
 pub fn validate_jwt(

--- a/server/src/tests/test_context.rs
+++ b/server/src/tests/test_context.rs
@@ -220,5 +220,7 @@ fn create_test_genesis_block(
     let hash = block_hash.block_hash(&genesis_header);
     let genesis_block = Block::new(genesis_header, Vec::new());
 
-    genesis_block.with_hash(hash).with_value(U256::ZERO)
+    genesis_block
+        .into_extended_with_hash(hash)
+        .with_value(U256::ZERO)
 }


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
With this we've cleaned up the suspicious field in/around API responses. Though size in bytes is definitely optional for block responses, geth at least does return it. Extra care was needed to be taken when calculating the byte size as the operation requires cloning and RLP encoding, so I tried to confine it to the write side of operations to allow it to be cheaply reconstructed on every block request.  
<!-- Fixes #123 -->
Closes #200.

### Changes
<!-- Key changes -->
- Changed the method name for block -> extended block conversion
- Extended the extended block repr to hold size as well
- Block size calculation at the block build stage

### Testing
<!-- How was it tested? -->
- [x] Block-related API tests return the field as expected
