### PR TITLE
fix(docker): build independent services first

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    
 
 concurrency:
   group: ${{ github.workflow }}
@@ -50,22 +49,17 @@ jobs:
 
       # Stage 1: Build and push base images first
       - name: Build base images
-        run: |
-          docker compose build optimism op-move geth
+        run: docker compose build optimism op-move geth
 
       - name: Push base images
-        run: |
-          docker compose push optimism op-move geth
+        run: docker compose push optimism op-move geth
 
       # Stage 2: Pull fresh base images, then build dependents
       - name: Pull fresh base images
-        run: |
-          docker compose pull optimism
+        run: docker compose pull optimism
 
       - name: Build dependent images
-        run: |
-          docker compose build op-node op-batcher op-proposer
+        run: docker compose build op-node op-batcher op-proposer
 
       - name: Push dependent images
-        run: |
-          docker compose push op-node op-batcher op-proposer
+        run: docker compose push op-node op-batcher op-proposer

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    
 
 concurrency:
   group: ${{ github.workflow }}
@@ -22,16 +24,48 @@ jobs:
     steps:
       - name: Free up disk space
         run: rm -rf /opt/hostedtoolcache
+
       - name: Clone repository
         uses: actions/checkout@v4
+
       - name: Log in to the registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
       - name: Set up Docker Buildx # Driver that supports cache export
         uses: docker/setup-buildx-action@v3
-      - name: Pull images
-        run: docker compose pull
+
+      # Previous published packages kept for possible rollback
+      - name: Backup current images as previous
+        run: |
+          ALL_SERVICES=("optimism" "op-move" "geth" "op-node" "op-batcher" "op-proposer")
+          for service in "${ALL_SERVICES[@]}"; do
+          echo "Retagging ghcr.io/uminetwork/${service}:latest as :previous"
+            docker compose pull ${service} || echo "No existing ${service}:latest found"
+            if docker image inspect ghcr.io/uminetwork/${service}:latest >/dev/null 2>&1; then
+              docker tag ghcr.io/uminetwork/${service}:latest ghcr.io/uminetwork/${service}:previous
+              docker push ghcr.io/uminetwork/${service}:previous
+            fi
+          done
         continue-on-error: true
-      - name: Build images
-        run: docker compose build
-      - name: Push images
-        run: docker compose push
+
+      # Stage 1: Build and push base images first
+      - name: Build base images
+        run: |
+          docker compose build optimism op-move geth
+
+      - name: Push base images
+        run: |
+          docker compose push optimism op-move geth
+
+      # Stage 2: Pull fresh base images, then build dependents
+      - name: Pull fresh base images
+        run: |
+          docker compose pull optimism
+
+      - name: Build dependent images
+        run: |
+          docker compose build op-node op-batcher op-proposer
+
+      - name: Push dependent images
+        run: |
+          docker compose push op-node op-batcher op-proposer


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
Deploy action in CI started failing after the most recent update to docker stack due to broken paths. That happened because the actual image used there was the one being pulled from the registry instead of the one built locally. This PR introduces a fix to that behavior and some rolling update tagging for peace of mind.
<!-- Fixes #123 -->

### Changes
<!-- Key changes -->
- Staged builds
- New `:previous` tag

### Testing
Temporary added PR trigger to the action, will remove if successful.