### PR TITLE
refactor(api): make engine API closer to the spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12291,6 +12291,7 @@ name = "umi-api"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "alloy-trie",
  "bcs 0.1.3",
  "move-core-types 0.0.4 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.27.2)",
  "op-alloy",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 [dependencies]
 alloy.workspace = true
 bcs.workspace = true
+alloy-trie.workspace = true
 umi-app.workspace = true
 umi-blockchain.workspace = true
 umi-evm-ext.workspace = true

--- a/api/src/jsonrpc.rs
+++ b/api/src/jsonrpc.rs
@@ -20,6 +20,14 @@ impl JsonRpcError {
         }
     }
 
+    pub fn invalid_fc_state() -> Self {
+        Self::without_data(-38002, "Invalid forkchoice state")
+    }
+
+    pub fn invalid_attributes() -> Self {
+        Self::without_data(-38003, "Invalid payload attributes")
+    }
+
     pub fn parse_error(request: serde_json::Value, message: impl Display) -> Self {
         Self {
             // invalid params code as defined in geth's beacon/engine/errors.go

--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -15,6 +15,7 @@ pub async fn execute_v3<'reader>(
     let payload_id: PayloadId = parse_params_1(request)?;
 
     // Spec: https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#specification-2
+    // unsupported fork if ts < cancun
     let response = match app.payload(payload_id.into())? {
         MaybePayloadResponse::Some(response) => response,
         MaybePayloadResponse::Delayed(mut rx) => {
@@ -192,6 +193,7 @@ mod tests {
             forkchoice_updated::execute_v3(
                 forkchoice_updated::tests::example_request(),
                 queue.clone(),
+                &reader,
                 &0x03421ee50df45cacu64,
             )
                 .await

--- a/api/src/methods/get_transaction_by_hash.rs
+++ b/api/src/methods/get_transaction_by_hash.rs
@@ -69,6 +69,7 @@ mod tests {
                 forkchoice_updated::execute_v3(
                     forkchoice_updated::tests::example_request(),
                     queue.clone(),
+                    &reader,
                     &0x03421ee50df45cacu64,
                 )
                 .await

--- a/api/src/methods/get_transaction_receipt.rs
+++ b/api/src/methods/get_transaction_receipt.rs
@@ -67,6 +67,7 @@ mod tests {
                 forkchoice_updated::execute_v3(
                     forkchoice_updated::tests::example_request(),
                     queue.clone(),
+                    &reader,
                     &0x03421ee50df45cacu64,
                 )
                 .await

--- a/api/src/request.rs
+++ b/api/src/request.rs
@@ -94,7 +94,9 @@ where
     }
 
     match method {
-        ForkChoiceUpdatedV3 => forkchoice_updated::execute_v3(request, queue, payload_id).await,
+        ForkChoiceUpdatedV3 => {
+            forkchoice_updated::execute_v3(request, queue, app, payload_id).await
+        }
         GetPayloadV3 => get_payload::execute_v3(request, app).await,
         NewPayloadV3 => new_payload::execute_v3(request, app).await,
         SendRawTransaction => {

--- a/api/src/schema/engine.rs
+++ b/api/src/schema/engine.rs
@@ -61,6 +61,11 @@ pub struct PayloadAttributesV3 {
     pub parent_beacon_block_root: B256,
     pub transactions: Vec<Bytes>,
     pub gas_limit: U64,
+    // TODO: (#201) allowed to be non-null only post-Holocene:
+    // <https://specs.optimism.io/protocol/holocene/exec-engine.html#dynamic-eip-1559-parameters>.
+    // Currently not propagated.
+    pub eip1559_params: Option<U64>,
+    pub no_tx_pool: Option<bool>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -279,6 +284,7 @@ impl From<PayloadAttributesV3> for Payload {
             parent_beacon_block_root: value.parent_beacon_block_root,
             transactions: value.transactions,
             gas_limit: value.gas_limit,
+            no_tx_pool: value.no_tx_pool,
         }
     }
 }

--- a/app/src/input.rs
+++ b/app/src/input.rs
@@ -18,6 +18,7 @@ pub struct Payload {
     pub parent_beacon_block_root: B256,
     pub transactions: Vec<Bytes>,
     pub gas_limit: U64,
+    pub no_tx_pool: Option<bool>,
 }
 
 /// Internal representation of [`Payload`] that has its `transactions`
@@ -31,6 +32,7 @@ pub struct PayloadForExecution {
     pub parent_beacon_block_root: B256,
     pub transactions: Vec<NormalizedExtendedTxEnvelope>,
     pub gas_limit: U64,
+    pub no_tx_pool: Option<bool>,
 }
 
 impl TryFrom<Payload> for PayloadForExecution {
@@ -53,6 +55,7 @@ impl TryFrom<Payload> for PayloadForExecution {
             parent_beacon_block_root: value.parent_beacon_block_root,
             transactions,
             gas_limit: value.gas_limit,
+            no_tx_pool: value.no_tx_pool,
         })
     }
 }

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -308,6 +308,7 @@ fn test_build_block_hash() {
         parent_beacon_block_root: Default::default(),
         transactions: Vec::new(),
         gas_limit: U64::from(0x1c9c380),
+        no_tx_pool: None,
     };
 
     let execution_outcome = ExecutionOutcome {

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -27,7 +27,7 @@ use {
             InMemoryBlockRepository, UmiBlockHash,
         },
         in_memory::shared_memory,
-        payload::{InMemoryPayloadQueries, InProgressPayloads},
+        payload::{InMemoryPayloadQueries, InProgressPayloads, MaybePayloadResponse},
         receipt::{InMemoryReceiptQueries, InMemoryReceiptRepository, receipt_memory},
         state::{BlockHeight, InMemoryStateQueries, MockStateQueries, StateQueries},
         transaction::{InMemoryTransactionQueries, InMemoryTransactionRepository},
@@ -1005,4 +1005,90 @@ fn test_gas_price_vs_max_priority_fee_difference() {
     let actual_base_fee = block.0.header.inner.base_fee_per_gas.unwrap_or_default();
 
     assert_eq!(difference, actual_base_fee as u128);
+}
+
+#[test]
+fn test_no_tx_pool_does_not_affect_mempool() {
+    let payload_signer = Signer::new(&[0xbb; 32]);
+    let initial_balance = U256::from(1_000_000_000);
+
+    let (reader, mut app) = create_app_with_fake_queries(
+        payload_signer.inner.address().to_move_address(),
+        initial_balance,
+        0,
+        0,
+    );
+
+    let mempool_tx = create_transaction(0); // Uses the default signer (0xaa...)
+    app.add_transaction(mempool_tx.clone());
+    assert_eq!(
+        app.mem_pool.len(),
+        1,
+        "Mempool should have one transaction before block build"
+    );
+
+    let mut payload_tx_raw = TxEip1559 {
+        chain_id: CHAIN_ID,
+        nonce: 0,
+        gas_limit: 21000,
+        max_fee_per_gas: 1_000_000_000,
+        max_priority_fee_per_gas: 1_000_000_000,
+        to: TxKind::Call(Address::random()),
+        value: U256::from(1),
+        access_list: Default::default(),
+        input: Default::default(),
+    };
+    let signature = payload_signer
+        .inner
+        .sign_transaction_sync(&mut payload_tx_raw)
+        .unwrap();
+    let payload_tx_envelope = TxEnvelope::Eip1559(payload_tx_raw.into_signed(signature));
+    let payload_tx: NormalizedEthTransaction = (UmiTxEnvelope::try_from(payload_tx_envelope)
+        .unwrap())
+    .try_into()
+    .unwrap();
+
+    let payload_attributes = PayloadForExecution {
+        no_tx_pool: Some(true),
+        transactions: vec![payload_tx.clone().into()],
+        ..Default::default()
+    };
+    let payload_id = U64::from(1);
+
+    app.start_block_build(payload_attributes, payload_id)
+        .unwrap();
+
+    assert_eq!(
+        app.mem_pool.len(),
+        1,
+        "Mempool should still have one transaction after block build"
+    );
+    let remaining_mempool_tx = app.mem_pool.iter().next().unwrap();
+    assert_eq!(
+        remaining_mempool_tx.tx_hash, mempool_tx.tx_hash,
+        "The transaction in the mempool should be the original one"
+    );
+
+    let payload_response =
+        if let MaybePayloadResponse::Some(payload) = reader.payload(payload_id).unwrap() {
+            payload
+        } else {
+            unreachable!("Payload should have been applied in block build")
+        };
+    assert_eq!(
+        payload_response.execution_payload.transactions.len(),
+        1,
+        "Built block should contain exactly one transaction"
+    );
+
+    let built_tx_bytes = &payload_response.execution_payload.transactions[0];
+    let built_tx_hash = alloy::primitives::keccak256(built_tx_bytes.as_ref());
+    assert_eq!(
+        built_tx_hash, payload_tx.tx_hash,
+        "The transaction in the block should be the one from payload_attributes"
+    );
+    assert_ne!(
+        built_tx_hash, mempool_tx.tx_hash,
+        "The transaction in the block should NOT be the one from the mempool"
+    );
 }

--- a/blockchain/src/transaction/write.rs
+++ b/blockchain/src/transaction/write.rs
@@ -28,7 +28,7 @@ impl ExtendedTransaction {
     ) -> Self {
         Self {
             effective_gas_price,
-            from: inner.from(),
+            from: inner.signer(),
             hash: inner.tx_hash(),
             inner: inner.into(),
             block_number,

--- a/execution/src/tests/evm_native.rs
+++ b/execution/src/tests/evm_native.rs
@@ -139,9 +139,9 @@ fn test_solidity_fixed_bytes() {
                 TxKind::Call(EVM_ADDRESS),
                 TransactionData::EntryFunction(entry_fn).to_bytes().unwrap(),
             );
-            let tx = tx.into_canonical().unwrap();
+            let tx = tx.as_canonical().unwrap();
             let input = CanonicalExecutionInput {
-                tx: &tx,
+                tx,
                 tx_hash: &tx.tx_hash,
                 state: state.resolver(),
                 storage_trie: evm_storage,

--- a/execution/src/transaction.rs
+++ b/execution/src/transaction.rs
@@ -167,17 +167,16 @@ impl From<NormalizedEthTransaction> for NormalizedExtendedTxEnvelope {
 }
 
 impl NormalizedExtendedTxEnvelope {
-    pub fn into_canonical(self) -> Option<NormalizedEthTransaction> {
-        if let Self::Canonical(tx) = self {
-            Some(tx)
-        } else {
-            None
-        }
-    }
-
     pub fn as_deposit(&self) -> Option<&TxDeposit> {
         match self {
             Self::DepositedTx(tx) => Some(tx),
+            _ => None,
+        }
+    }
+
+    pub fn as_canonical(&self) -> Option<&NormalizedEthTransaction> {
+        match self {
+            Self::Canonical(tx) => Some(tx),
             _ => None,
         }
     }

--- a/execution/src/transaction.rs
+++ b/execution/src/transaction.rs
@@ -221,7 +221,7 @@ impl NormalizedExtendedTxEnvelope {
         self.tx_hash()
     }
 
-    pub fn from(&self) -> Address {
+    pub fn signer(&self) -> Address {
         match self {
             Self::Canonical(tx) => tx.signer,
             Self::DepositedTx(tx) => tx.from,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,6 +14,7 @@ storage-rocksdb = ["umi-storage-rocksdb"]
 workspace = true
 
 [dependencies]
+alloy.workspace = true
 anyhow.workspace = true
 aptos-types.workspace = true
 bcs.workspace = true
@@ -48,7 +49,6 @@ warp.workspace = true
 warp-reverse-proxy.workspace = true
 
 [dev-dependencies]
-alloy.workspace = true
 criterion.workspace = true
 dotenvy.workspace = true
 eth_trie.workspace = true

--- a/server/benches/perf/queue/input.rs
+++ b/server/benches/perf/queue/input.rs
@@ -80,6 +80,7 @@ pub fn blocks_1000() -> impl Iterator<Item = Command> {
                 parent_beacon_block_root: B256::ZERO,
                 transactions: vec![tx.clone()],
                 gas_limit: U64::from_limbs([30000000u64]),
+                no_tx_pool: None,
             }
             .try_into()
             .unwrap(),

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,5 +1,6 @@
 use {
     crate::mirror::MirrorLog,
+    alloy::consensus::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH},
     jsonwebtoken::{DecodingKey, Validation},
     move_core_types::account_address::AccountAddress,
     std::{
@@ -26,9 +27,7 @@ use {
     },
     umi_shared::{
         hex,
-        primitives::{
-            ToSaturatedU64, B2048, B256, B64, EMPTY_LIST_ROOT, EMPTY_OMMERS_ROOT_HASH, U256,
-        },
+        primitives::{ToSaturatedU64, B2048, B256, B64, U256},
     },
     warp::{
         http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, StatusCode},
@@ -294,15 +293,15 @@ fn create_genesis_block(
         number: genesis_config.l2_contract_genesis.number.unwrap_or(0),
         parent_beacon_block_root: Some(B256::ZERO),
         parent_hash: B256::ZERO,
-        receipts_root: EMPTY_LIST_ROOT,
+        receipts_root: EMPTY_ROOT_HASH,
         state_root: B256::new(hex!(
             "30b67e4b5ef34eacb9e083c07fd5578982c2cb4e0ee1dc0a14d72b99a28ed80e"
         )),
         timestamp: genesis_config.l2_contract_genesis.timestamp,
-        transactions_root: EMPTY_LIST_ROOT,
-        withdrawals_root: Some(EMPTY_LIST_ROOT),
+        transactions_root: EMPTY_ROOT_HASH,
+        withdrawals_root: Some(EMPTY_ROOT_HASH),
         beneficiary: genesis_config.l2_contract_genesis.coinbase,
-        ommers_hash: EMPTY_OMMERS_ROOT_HASH,
+        ommers_hash: EMPTY_OMMER_ROOT_HASH,
         requests_hash: None,
     };
     let hash = block_hash.block_hash(&genesis_header);

--- a/shared/src/primitives.rs
+++ b/shared/src/primitives.rs
@@ -4,21 +4,10 @@ pub use {
 };
 
 use {
-    alloy::{
-        consensus::{Receipt, ReceiptWithBloom},
-        hex,
-    },
+    alloy::consensus::{Receipt, ReceiptWithBloom},
     move_core_types::{account_address::AccountAddress, u256::U256 as MoveU256},
     op_alloy::consensus::{OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope},
 };
-
-pub const EMPTY_LIST_ROOT: B256 = B256::new(hex!(
-    "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
-));
-
-pub const EMPTY_OMMERS_ROOT_HASH: B256 = B256::new(hex!(
-    "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
-));
 
 pub trait ToEthAddress {
     fn to_eth_address(&self) -> Address;


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
Make our engine API closer to the spec by running more validations. Some tests are still failing, and I'll probably write at least some new ones, but otherwise good to go.
<!-- Fixes #123 -->
Fixes #63.

### Changes
<!-- Key changes -->
- `forkchoiceUpdated` and `newPayload` with more thorough validation
- Some fresh fields from OP spec
- Changed the way mempool txs are treated. Instead of being drained unconditionally, they're only cleaned up at the end of block build now

### Testing
<!-- How was it tested? -->
- [x] Old tests passing: new_payload API test had a sneaky hard-coded value in it, so I refactored it with more sensible flow. 
- [x] Write some new tests: integration-style one for the `no_tx_pool` flag.