### PR TITLE
Fix(genesis): Test root hash to match genesis config

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -74,7 +74,7 @@ pub fn defaults() -> DefaultLayer {
         genesis: Some(OptionalGenesis {
             chain_id: Some(42069),
             initial_state_root: Some(B256::new(hex!(
-                "4805267476cb522274ec2fe790b4dc6e889ed0d57377f90770d4a658f6b8e4ae"
+                "7a60fc9568ab4beac4305f381312125963c32ffb7a0d5b3afdd4a9ecca902348"
             ))),
             treasury: Some(AccountAddress::ONE), // TODO: fill in the real address,
             l2_contract_genesis: Some(


### PR DESCRIPTION
### Description
Root hash is changed in [genesis config](https://github.com/MovedNetwork/op-move/blob/99532c8c1d6a18beba12389f71d0600c1fffd38f/genesis/src/config.rs#L98) but not in the default server config.

### Changes
- Update the root hash in default config with the one in genesis config

### Testing
Integration test works, it was failing before.

### Notes
Why don't we use `GenesisConfig::default()` here? Instead of duplicating and potentially missing to update both values.