### PR TITLE
Chore: refactor gas price type as u128

### DIFF
--- a/app/src/query.rs
+++ b/app/src/query.rs
@@ -455,15 +455,13 @@ impl<'app, D: Dependencies<'app>> ApplicationReader<'app, D> {
         if matches!(block_id, BlockNumberOrHash::Number(_)) {
             // Reusing the parameters from the prod config
             // TODO: pass a constant
-            let gas_fee = Eip1559GasFee::new(6, U256::from_limbs([250, 0, 0, 0]));
-            let next_block_base_fee = gas_fee
-                .base_fee_per_gas(
-                    gas_limit,
-                    block_gas_used,
-                    U256::from(base_fee_per_gas.unwrap_or_default()),
-                )
-                .saturating_to();
-            base_fees.push(next_block_base_fee);
+            let gas_fee = Eip1559GasFee::new(6, 250);
+            let next_block_base_fee = gas_fee.base_fee_per_gas(
+                gas_limit,
+                block_gas_used,
+                base_fee_per_gas.unwrap_or_default(),
+            );
+            base_fees.push(next_block_base_fee.into());
         }
 
         base_fees.push(base_fee_per_gas.unwrap_or_default().into());

--- a/blockchain/src/receipt/read.rs
+++ b/blockchain/src/receipt/read.rs
@@ -47,8 +47,7 @@ impl From<ExtendedReceipt> for TransactionReceipt {
                 block_hash: Some(rx.block_hash),
                 block_number: Some(rx.block_number),
                 gas_used: rx.gas_used,
-                // TODO: make all gas prices bounded by u128?
-                effective_gas_price: rx.l2_gas_price.saturating_to(),
+                effective_gas_price: rx.l2_gas_price,
                 // Always None because we do not support eip-4844 transactions
                 blob_gas_used: None,
                 blob_gas_price: None,

--- a/blockchain/src/receipt/write.rs
+++ b/blockchain/src/receipt/write.rs
@@ -1,7 +1,7 @@
 use {
     op_alloy::{consensus::OpReceiptEnvelope, rpc_types::L1BlockInfo},
     std::fmt::Debug,
-    umi_shared::primitives::{Address, B256, U256},
+    umi_shared::primitives::{Address, B256},
 };
 
 pub trait ReceiptRepository {
@@ -26,7 +26,7 @@ pub struct ExtendedReceipt {
     pub receipt: OpReceiptEnvelope,
     pub l1_block_info: Option<L1BlockInfo>,
     pub gas_used: u64,
-    pub l2_gas_price: U256,
+    pub l2_gas_price: u128,
     /// If the transaction deployed a new contract, gives the address.
     ///
     /// In Move contracts are identified by AccountAddress + ModuleID,

--- a/blockchain/src/transaction/read.rs
+++ b/blockchain/src/transaction/read.rs
@@ -29,7 +29,7 @@ impl From<ExtendedTransaction> for TransactionResponse {
                 block_hash: Some(value.block_hash),
                 block_number: Some(value.block_number),
                 transaction_index: Some(value.transaction_index),
-                effective_gas_price: Some(value.effective_gas_price.saturating_to()),
+                effective_gas_price: Some(value.effective_gas_price),
             },
             deposit_nonce,
             deposit_receipt_version,

--- a/blockchain/src/transaction/write.rs
+++ b/blockchain/src/transaction/write.rs
@@ -15,12 +15,12 @@ pub struct ExtendedTransaction {
     pub block_number: u64,
     pub block_hash: B256,
     pub transaction_index: u64,
-    pub effective_gas_price: U256,
+    pub effective_gas_price: u128,
 }
 
 impl ExtendedTransaction {
     pub fn new(
-        effective_gas_price: U256,
+        effective_gas_price: u128,
         inner: NormalizedExtendedTxEnvelope,
         block_number: u64,
         block_hash: B256,

--- a/execution/src/canonical.rs
+++ b/execution/src/canonical.rs
@@ -43,7 +43,7 @@ use {
     umi_shared::{
         error::{
             Error::{InvalidTransaction, User},
-            EthToken, InvalidTransactionCause, UserError,
+            EthToken, InvalidTransactionCause,
         },
         primitives::ToMoveAddress,
         resolver_utils::{ChangesBasedResolver, PairedResolvers},
@@ -150,9 +150,7 @@ pub(super) fn execute_canonical_transaction<
         .try_into()
         .map(FeePerGasUnit::new)
         .map_err(|_| {
-            User(UserError::InvalidGasPrice(
-                input.l2_input.effective_gas_price,
-            ))
+            InvalidTransactionCause::InvalidGasPrice(input.l2_input.effective_gas_price)
         })?;
     let umi_vm = UmiVm::new(input.genesis_config);
     let module_bytes_storage = ResolverBasedModuleBytesStorage::new(&cached_resolver);
@@ -165,7 +163,7 @@ pub(super) fn execute_canonical_transaction<
         input.genesis_config,
         input.block_header,
         tx_data.script_hash(),
-    );
+    )?;
     let eth_transfers_logger = EthTransfersLogger::default();
     let mut session = create_vm_session(
         &vm,

--- a/execution/src/deposited.rs
+++ b/execution/src/deposited.rs
@@ -160,13 +160,9 @@ pub(super) fn execute_deposited_transaction<
         evm_changes.storage,
     );
 
+    // L2 gas price is set to 0 since deposit transactions are only
+    // executed by the system and therefore do not consume any user gas.
     Ok(TransactionExecutionOutcome::new(
-        vm_outcome,
-        changes,
-        gas_used,
-        // No L2 gas for deposited txs
-        U256::ZERO,
-        logs,
-        None,
+        vm_outcome, changes, gas_used, 0, logs, None,
     ))
 }

--- a/execution/src/session_id.rs
+++ b/execution/src/session_id.rs
@@ -1,6 +1,5 @@
 use {
     crate::transaction::NormalizedEthTransaction,
-    alloy::primitives::U256,
     aptos_types::transaction::EntryFunction,
     aptos_vm::move_vm_ext::UserTransactionContext,
     op_alloy::consensus::TxDeposit,
@@ -39,7 +38,7 @@ impl SessionId {
             Vec::new(),
             sender,
             tx.gas_limit(),
-            u64_gas_price(&tx.max_fee_per_gas),
+            u64_gas_price(tx.max_fee_per_gas),
             chain_id,
             maybe_entry_fn.map(EntryFunction::as_entry_function_payload),
             None,
@@ -81,12 +80,8 @@ impl SessionId {
     }
 }
 
-// TODO: Should we make it an invariant that the gas price is always less than u64::MAX?
-fn u64_gas_price(u256_gas_price: &U256) -> u64 {
-    match u256_gas_price.as_limbs() {
-        [value, 0, 0, 0] => *value,
-        _ => u64::MAX,
-    }
+fn u64_gas_price(u128_gas_price: u128) -> u64 {
+    u128_gas_price.try_into().unwrap_or(u64::MAX)
 }
 
 /// Ethereum uses U256 (and most projects on Ethereum use u64) for chain id,

--- a/execution/src/simulate.rs
+++ b/execution/src/simulate.rs
@@ -60,7 +60,7 @@ pub fn simulate_transaction(
         chain_id: genesis_config.chain_id,
     };
 
-    let l2_input = L2GasFeeInput::new(u64::MAX, U256::ZERO);
+    let l2_input = L2GasFeeInput::new(u64::MAX, 0);
     let l2_fee = CreateUmiL2GasFee.with_default_gas_fee_multiplier();
     let input = CanonicalExecutionInput {
         tx: &tx,

--- a/execution/src/simulate.rs
+++ b/execution/src/simulate.rs
@@ -105,7 +105,7 @@ pub fn call_transaction(
         genesis_config,
         block_header,
         tx_data.script_hash(),
-    );
+    )?;
     let mut session =
         create_vm_session(&vm, state, session_id, storage_trie, &(), block_hash_lookup);
     let traversal_storage = TraversalStorage::new();

--- a/execution/src/tests/evm_native.rs
+++ b/execution/src/tests/evm_native.rs
@@ -148,7 +148,7 @@ fn test_solidity_fixed_bytes() {
                 genesis_config: &ctx.genesis_config,
                 l1_cost: U256::ZERO,
                 l2_fee: U256::ZERO,
-                l2_input: (u64::MAX, U256::ZERO).into(),
+                l2_input: (u64::MAX, 0).into(),
                 base_token: &(),
                 block_header: HeaderForExecution::default(),
                 block_hash_lookup: &(),

--- a/execution/src/tests/gas_cost.rs
+++ b/execution/src/tests/gas_cost.rs
@@ -16,7 +16,7 @@ fn test_treasury_charges_l1_and_l2_cost_to_sender_account_on_success() {
     let l1_cost = 1;
     // Set a gas limit higher than the cost of operation
     let l2_gas_limit = 100_000;
-    let l2_gas_price = U256::from(10).pow(U256::from(9)); // 1 Gwei
+    let l2_gas_price = 10_u64.pow(9); // 1 Gwei
     let receiver = ALT_EVM_ADDRESS;
     let transfer_amount = mint_amount.wrapping_shr(2);
 
@@ -31,9 +31,7 @@ fn test_treasury_charges_l1_and_l2_cost_to_sender_account_on_success() {
         .expect("Transfer should succeed");
     outcome.vm_outcome.unwrap();
 
-    let l2_cost = outcome
-        .gas_used
-        .saturating_mul(l2_gas_price.saturating_to());
+    let l2_cost = outcome.gas_used.saturating_mul(l2_gas_price);
     let expected_sender_balance = mint_amount - transfer_amount - U256::from(l1_cost + l2_cost);
     let sender_balance = ctx.get_balance(sender);
     assert_eq!(sender_balance, expected_sender_balance);
@@ -54,7 +52,7 @@ fn test_treasury_charges_correct_l1_and_l2_cost_to_sender_account_on_user_error(
     let l1_cost = 1;
     // Set a gas limit higher than the cost of operation
     let l2_gas_limit = 100_000;
-    let l2_gas_price = U256::from(2);
+    let l2_gas_price = 2;
     let receiver = ALT_EVM_ADDRESS;
     let transfer_amount = mint_amount.saturating_add(U256::from(1));
 
@@ -71,9 +69,7 @@ fn test_treasury_charges_correct_l1_and_l2_cost_to_sender_account_on_user_error(
     assert!(outcome.vm_outcome.is_err());
 
     let sender_balance = ctx.get_balance(sender);
-    let l2_cost = outcome
-        .gas_used
-        .saturating_mul(l2_gas_price.saturating_to());
+    let l2_cost = outcome.gas_used.saturating_mul(l2_gas_price);
     let expected_sender_balance = mint_amount - U256::from(l1_cost + l2_cost);
     let receiver_balance = ctx.get_balance(receiver);
 
@@ -92,7 +88,7 @@ fn test_very_low_gas_limit_makes_tx_invalid() {
     ctx.deposit_eth(sender, mint_amount);
 
     let l1_cost = 1;
-    let l2_gas_price = U256::from(2);
+    let l2_gas_price = 2;
     let receiver = ALT_EVM_ADDRESS;
     let transfer_amount = mint_amount.wrapping_shr(1);
 
@@ -134,7 +130,7 @@ fn test_low_gas_limit_gets_charged_and_fails_the_tx() {
     ctx.deposit_eth(sender, mint_amount);
 
     let l1_cost = 1;
-    let l2_gas_price = U256::from(2);
+    let l2_gas_price = 2;
     let receiver = ALT_EVM_ADDRESS;
     let transfer_amount = mint_amount.wrapping_shr(1);
 
@@ -148,7 +144,7 @@ fn test_low_gas_limit_gets_charged_and_fails_the_tx() {
         l2_gas_price,
     );
 
-    let l2_cost = l2_gas_limit.saturating_mul(l2_gas_price.saturating_to());
+    let l2_cost = l2_gas_limit.saturating_mul(l2_gas_price);
     let expected_sender_balance = mint_amount - U256::from(l1_cost + l2_cost);
     let sender_balance = ctx.get_balance(sender);
     let receiver_balance = ctx.get_balance(receiver);
@@ -172,7 +168,7 @@ fn test_storage_update_cost() {
 
     let gas_limit = 50_000;
     // Choose gas price equal to 1 for convenience in checking how much the gas changes.
-    let gas_price = U256::ONE;
+    let gas_price = 1;
 
     // Create the resource
     let text = "Hello, world";

--- a/execution/src/tests/transfer.rs
+++ b/execution/src/tests/transfer.rs
@@ -39,7 +39,7 @@ fn test_initiate_withdrawal() {
     let withdraw_amount = U256::from(1_000);
     let l2_parser = address!("4200000000000000000000000000000000000016");
     // Transfering an amount to L2ToL1MessageParser triggers the withdrawal method via `receive() payable`
-    let outcome = ctx.transfer(l2_parser, withdraw_amount, 0, u64::MAX, U256::ZERO);
+    let outcome = ctx.transfer(l2_parser, withdraw_amount, 0, u64::MAX, 0);
 
     // Topic signature of MessagePassed event. The signature is generated with the command below:
     // cast sig-event "MessagePassed(uint256 indexed nonce, address indexed sender, address indexed target, uint256 value, uint256 gasLimit, bytes data, bytes32 withdrawalHash)"
@@ -119,13 +119,13 @@ fn test_eoa_base_token_transfer() {
     let receiver = ALT_EVM_ADDRESS;
     let transfer_amount = mint_amount.saturating_add(U256::from(1));
     // Still need to set gas limit for proper functioning of the gas meter
-    let outcome = ctx.transfer(receiver, transfer_amount, 0, u64::MAX, U256::ZERO);
+    let outcome = ctx.transfer(receiver, transfer_amount, 0, u64::MAX, 0);
     assert!(outcome.unwrap().vm_outcome.is_err());
 
     // Should work with proper transfer
     let transfer_amount = mint_amount.wrapping_shr(1);
     // Still need to set gas limit for proper functioning of the gas meter
-    let outcome = ctx.transfer(receiver, transfer_amount, 0, u64::MAX, U256::ZERO);
+    let outcome = ctx.transfer(receiver, transfer_amount, 0, u64::MAX, 0);
     assert!(outcome.unwrap().vm_outcome.is_ok());
 
     let sender_balance = ctx.get_balance(sender);

--- a/execution/src/tests/utils.rs
+++ b/execution/src/tests/utils.rs
@@ -46,7 +46,7 @@ pub struct TestTransaction {
     /// L2 gas limit associated with the transaction
     pub l2_gas_limit: u64,
     /// L2 gas price associated with the transaction
-    pub l2_gas_price: U256,
+    pub l2_gas_price: u128,
     /// Base token state for the transaction
     pub base_token: TestBaseToken,
 }
@@ -66,7 +66,7 @@ impl TestTransaction {
             l1_cost: 0,
             base_token: TestBaseToken::Empty,
             l2_gas_limit: gas_limit,
-            l2_gas_price: U256::ZERO,
+            l2_gas_price: 0,
         }
     }
 
@@ -82,7 +82,7 @@ impl TestTransaction {
         l1_cost: u64,
         base_token: UmiBaseTokenAccounts,
         l2_gas_limit: u64,
-        l2_gas_price: U256,
+        l2_gas_price: u128,
     ) {
         self.l1_cost = l1_cost;
         self.base_token = TestBaseToken::Umi(base_token);
@@ -195,7 +195,7 @@ impl TestContext {
         amount: U256,
         l1_cost: u64,
         l2_gas_limit: u64,
-        l2_gas_price: U256,
+        l2_gas_price: u64,
     ) -> umi_shared::error::Result<TransactionExecutionOutcome> {
         let tx = create_transaction_with_value(
             &mut self.signer,
@@ -208,7 +208,7 @@ impl TestContext {
         let treasury_address = AccountAddress::ONE;
         let base_token = UmiBaseTokenAccounts::new(treasury_address);
         let mut transaction = TestTransaction::new(tx);
-        transaction.with_cost_and_token(l1_cost, base_token, l2_gas_limit, l2_gas_price);
+        transaction.with_cost_and_token(l1_cost, base_token, l2_gas_limit, l2_gas_price.into());
         let outcome = self.execute_tx(&transaction)?;
         self.state.apply(outcome.changes.move_vm.clone()).unwrap();
         self.evm_storage.apply(outcome.changes.evm.clone()).unwrap();
@@ -259,7 +259,7 @@ impl TestContext {
         module_id: &ModuleId,
         function: &str,
         args: impl IntoIterator<Item = &'a MoveValue>,
-        gas_price: U256,
+        gas_price: u128,
         gas_limit: u64,
     ) -> TransactionExecutionOutcome {
         let args = args

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -91,7 +91,7 @@ pub fn defaults() -> DefaultLayer {
 }
 
 const EIP1559_ELASTICITY_MULTIPLIER: u64 = 6;
-const EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR: U256 = U256::from_limbs([250, 0, 0, 0]);
+const EIP1559_BASE_FEE_MAX_CHANGE_DENOMINATOR: u128 = 250;
 const JWT_VALID_DURATION_IN_SECS: u64 = 60;
 
 pub fn set_global_tracing_subscriber() {

--- a/shared/src/error.rs
+++ b/shared/src/error.rs
@@ -105,8 +105,6 @@ pub enum UserError {
     MissingModule(String),
     #[error("Missing resource requested: {0}")]
     MissingResource(String),
-    #[error("Given gas price {0} is too high. Must be less than u64::MAX.")]
-    InvalidGasPrice(u128),
 }
 
 /// The error caused by invalid transaction input parameter.
@@ -148,6 +146,8 @@ pub enum InvalidTransactionCause {
     FailedToPayL1Fee,
     #[error("Failed to pay L2 fee")]
     FailedToPayL2Fee,
+    #[error("Given gas price {0} is too high. Must be less than u64::MAX.")]
+    InvalidGasPrice(u128),
 }
 
 impl From<InvalidTransactionCause> for Error {

--- a/shared/src/error.rs
+++ b/shared/src/error.rs
@@ -105,6 +105,8 @@ pub enum UserError {
     MissingModule(String),
     #[error("Missing resource requested: {0}")]
     MissingResource(String),
+    #[error("Given gas price {0} is too high. Must be less than u64::MAX.")]
+    InvalidGasPrice(u128),
 }
 
 /// The error caused by invalid transaction input parameter.

--- a/storage/rocksdb/src/transaction.rs
+++ b/storage/rocksdb/src/transaction.rs
@@ -119,7 +119,7 @@ mod tests {
         let normalized_tx = NormalizedEthTransaction::try_from(signed_tx).unwrap();
 
         let transaction = ExtendedTransaction::new(
-            U256::ONE,
+            1,
             normalized_tx.into(),
             1,
             B256::new(hex!(
@@ -150,7 +150,7 @@ mod tests {
         let sealed_tx = NormalizedExtendedTxEnvelope::DepositedTx(tx.seal_slow());
 
         let transaction = ExtendedTransaction::new(
-            U256::ONE,
+            1,
             sealed_tx,
             1,
             B256::new(hex!(


### PR DESCRIPTION
### Description
Closes #227 
Closes #255 

This PR sets the gas price type based on alloy (u128 for general gas prices, u64 for base fee). Aptos only accepts u64 gas prices, so there is also a check at the start of executing canonical transaction that the gas price fits in a u64. It is an invalid transaction error if it does not fix because the priority fee is set as part of the transaction and the base fee is already a u64. Note this should never be a limitation in practice because a u64 variable can represent 18 ETH, and the smallest transaction costs 21k gas, which means if the gas price exceeds a u64 then even a basic transfer would cost millions of dollars; quite an unrealistic scenario.

### Changes
- Represent general gas price as u128
- Represent base fee as u64.

### Testing
- Existing tests
- New `test_invalid_gas_price`
