### PR TITLE
Chore: Refactor execute_evm_contract to have fewer arguments

### DIFF
--- a/execution/src/canonical.rs
+++ b/execution/src/canonical.rs
@@ -4,8 +4,8 @@ use {
         CanonicalExecutionInput, Logs, create_vm_session,
         eth_token::{self, BaseTokenAccounts, TransferArgs},
         execute::{
-            deploy_evm_contract, deploy_module, execute_entry_function, execute_evm_contract,
-            execute_script,
+            EvmExecutionArgs, deploy_evm_contract, deploy_module, execute_entry_function,
+            execute_evm_contract, execute_script,
         },
         gas::{new_gas_meter, total_gas_used},
         nonces::check_nonce,
@@ -250,10 +250,12 @@ pub(super) fn execute_canonical_transaction<
             )
         }
         TransactionData::L2Contract(contract) => execute_evm_contract(
-            &sender_move_address,
-            &contract.to_move_address(),
-            input.tx.value,
-            input.tx.data.to_vec(),
+            EvmExecutionArgs::new(
+                sender_move_address,
+                contract.to_move_address(),
+                input.tx.value,
+                input.tx.data.to_vec(),
+            ),
             &mut session,
             &mut traversal_context,
             &mut gas_meter,
@@ -261,10 +263,12 @@ pub(super) fn execute_canonical_transaction<
         )
         .map(|_| ()),
         TransactionData::EvmContract { address, data } => execute_evm_contract(
-            &sender_move_address,
-            &address.to_move_address(),
-            input.tx.value,
-            data,
+            EvmExecutionArgs::new(
+                sender_move_address,
+                address.to_move_address(),
+                input.tx.value,
+                data,
+            ),
             &mut session,
             &mut traversal_context,
             &mut gas_meter,

--- a/execution/src/simulate.rs
+++ b/execution/src/simulate.rs
@@ -4,7 +4,7 @@ use {
         BaseTokenAccounts, CanonicalExecutionInput,
         canonical::{CanonicalVerificationInput, verify_transaction},
         create_vm_session,
-        execute::execute_evm_contract,
+        execute::{EvmExecutionArgs, execute_evm_contract},
         execute_transaction,
         gas::new_gas_meter,
         quick_get_nonce,
@@ -35,7 +35,6 @@ use {
     umi_state::ResolverBasedModuleBytesStorage,
 };
 
-#[allow(clippy::too_many_arguments)]
 pub fn simulate_transaction(
     request: TransactionRequest,
     state: &(impl MoveResolver + TableResolver),
@@ -158,10 +157,12 @@ pub fn call_transaction(
         }
         TransactionData::L2Contract(contract) => {
             let outcome = execute_evm_contract(
-                &tx.signer.to_move_address(),
-                &contract.to_move_address(),
-                tx.value,
-                tx.data.to_vec(),
+                EvmExecutionArgs::new(
+                    tx.signer.to_move_address(),
+                    contract.to_move_address(),
+                    tx.value,
+                    tx.data.to_vec(),
+                ),
                 &mut session,
                 &mut traversal_context,
                 &mut gas_meter,
@@ -171,10 +172,12 @@ pub fn call_transaction(
         }
         TransactionData::EvmContract { address, data } => {
             let outcome = execute_evm_contract(
-                &tx.signer.to_move_address(),
-                &address.to_move_address(),
-                tx.value,
-                data,
+                EvmExecutionArgs::new(
+                    tx.signer.to_move_address(),
+                    address.to_move_address(),
+                    tx.value,
+                    data,
+                ),
                 &mut session,
                 &mut traversal_context,
                 &mut gas_meter,


### PR DESCRIPTION
### Description
Closes #329 

### Changes
- Refactor `execute_evm_contract` to take a struct instead of too many arguments.

### Testing
- Existing tests