### PR TITLE
Refactor(server): Remove port param

### DIFF
--- a/server/src/mirror.rs
+++ b/server/src/mirror.rs
@@ -1,8 +1,0 @@
-use {serde::Serialize, umi_api::jsonrpc::JsonRpcResponse};
-
-#[derive(Debug, Serialize)]
-pub struct MirrorLog<'a> {
-    pub request: &'a serde_json::Value,
-    pub op_move_response: &'a JsonRpcResponse,
-    pub port: &'a str,
-}

--- a/server/src/tests/test_context.rs
+++ b/server/src/tests/test_context.rs
@@ -250,7 +250,7 @@ impl TestContext<'static> {
         &self,
         request: &serde_json::Value,
     ) -> anyhow::Result<T> {
-        let server = crate::server_filter(&self.queue, &self.reader, "1234", &allow::auth, None);
+        let server = crate::server_filter(&self.queue, &self.reader, &allow::auth, None);
 
         let response = warp::test::request()
             .method("POST")


### PR DESCRIPTION
### Description
Port is only passed in for logging, so it's unused in production.

### Changes
- Remove port param
- Move `MirrorLog` into server as `ServerLog`

### Testing
✓ unit tests, fmt, clippy pass
✓ integration test works