### PR TITLE
Feat(EVM): Synchronize Move and EVM nonces

### DIFF
--- a/blockchain/src/state/read/tests.rs
+++ b/blockchain/src/state/read/tests.rs
@@ -10,7 +10,9 @@ use {
     move_vm_types::{gas::UnmeteredGasMeter, resolver::MoveResolver},
     std::sync::Arc,
     umi_evm_ext::state::InMemoryStorageTrieRepository,
-    umi_execution::{check_nonce, create_vm_session, mint_eth, session_id::SessionId},
+    umi_execution::{
+        check_nonce, create_vm_session, increment_account_nonce, mint_eth, session_id::SessionId,
+    },
     umi_genesis::{CreateMoveVm, UmiVm, config::GenesisConfig},
     umi_shared::primitives::{B256, U256},
     umi_state::{Changes, InMemoryState, InMemoryTrieDb, ResolverBasedModuleBytesStorage, State},
@@ -245,6 +247,14 @@ fn inc_one_nonce(old_nonce: u64, state: &mut impl State, addr: AccountAddress) -
 
     check_nonce(
         old_nonce,
+        &addr,
+        &mut session,
+        &mut traversal_context,
+        &mut gas_meter,
+        &code_storage,
+    )
+    .unwrap();
+    increment_account_nonce(
         &addr,
         &mut session,
         &mut traversal_context,

--- a/evm-ext/src/lib.rs
+++ b/evm-ext/src/lib.rs
@@ -7,9 +7,10 @@ pub use self::{
         evm_transact_with_native,
     },
     state_changes::{
-        Changes, extract_evm_changes, extract_evm_changes_from_native, genesis_state_changes,
+        Changes, extract_evm_changes, extract_evm_changes_from_native, extract_evm_nonces,
+        genesis_state_changes,
     },
-    type_utils::extract_evm_result,
+    type_utils::{ACCOUNT_MODULE_NAME, ACCOUNT_RESOURCE_NAME, extract_evm_result},
 };
 
 use {

--- a/evm-ext/src/state_changes.rs
+++ b/evm-ext/src/state_changes.rs
@@ -16,6 +16,7 @@ use {
         primitives::{Address, KECCAK_EMPTY, U256},
         state::{Account, AccountInfo, AccountStatus, EvmStorageSlot},
     },
+    std::collections::HashMap,
 };
 
 #[derive(Debug, Clone)]
@@ -93,6 +94,21 @@ pub fn genesis_state_changes(
 pub fn extract_evm_changes(extensions: &NativeContextExtensions) -> Result<Changes, Error> {
     let evm_native_ctx = extensions.get::<NativeEVMContext>();
     extract_evm_changes_from_native(evm_native_ctx)
+}
+
+pub fn extract_evm_nonces(extensions: &NativeContextExtensions) -> HashMap<Address, u64> {
+    let evm_native_ctx = extensions.get::<NativeEVMContext>();
+    let mut result = HashMap::new();
+    for state in &evm_native_ctx.state_changes {
+        for (address, account) in state {
+            // See comment below about why these accounts should be skipped
+            if !account.is_touched() || account.is_selfdestructed() {
+                continue;
+            }
+            result.insert(*address, account.info.nonce);
+        }
+    }
+    result
 }
 
 pub fn extract_evm_changes_from_native(

--- a/execution/src/lib.rs
+++ b/execution/src/lib.rs
@@ -5,7 +5,7 @@ pub use {
         CreateEcotoneL1GasFee, CreateL1GasFee, CreateL2GasFee, CreateUmiL2GasFee, EcotoneGasFee,
         L1GasFee, L1GasFeeInput, L2GasFee, L2GasFeeInput, UmiGasFee,
     },
-    nonces::{check_nonce, quick_get_nonce},
+    nonces::{check_nonce, increment_account_nonce, quick_get_nonce},
 };
 
 use {

--- a/execution/src/nonces.rs
+++ b/execution/src/nonces.rs
@@ -1,5 +1,6 @@
 use {
     crate::session_id::SessionId,
+    alloy::primitives::Address,
     aptos_table_natives::TableResolver,
     move_core_types::{
         account_address::AccountAddress, ident_str, identifier::IdentStr,
@@ -15,13 +16,17 @@ use {
         resolver::MoveResolver,
         value_serde::ValueSerDeContext,
     },
+    std::collections::HashMap,
     umi_evm_ext::state::StorageTrieRepository,
     umi_genesis::{CreateMoveVm, FRAMEWORK_ADDRESS, UmiVm},
-    umi_shared::error::{Error, InvalidTransactionCause, NonceChecking},
+    umi_shared::{
+        error::{Error, InvalidTransactionCause, NonceChecking},
+        primitives::ToMoveAddress,
+    },
     umi_state::ResolverBasedModuleBytesStorage,
 };
 
-const ACCOUNT_MODULE_NAME: &IdentStr = ident_str!("account");
+const ACCOUNT_MODULE_NAME: &IdentStr = umi_evm_ext::ACCOUNT_MODULE_NAME;
 const CREATE_ACCOUNT_FUNCTION_NAME: &IdentStr = ident_str!("create_account_if_does_not_exist");
 const GET_NONCE_FUNCTION_NAME: &IdentStr = ident_str!("get_sequence_number");
 const INCREMENT_NONCE_FUNCTION_NAME: &IdentStr = ident_str!("increment_sequence_number");
@@ -105,6 +110,19 @@ pub fn check_nonce<G: GasMeter, MS: ModuleStorage>(
         Err(InvalidTransactionCause::ExhaustedAccount)?;
     }
 
+    Ok(())
+}
+
+pub fn increment_account_nonce<G: GasMeter, MS: ModuleStorage>(
+    signer: &AccountAddress,
+    session: &mut Session,
+    traversal_context: &mut TraversalContext,
+    gas_meter: &mut G,
+    module_storage: &MS,
+) -> Result<(), Error> {
+    let account_module_id = ModuleId::new(FRAMEWORK_ADDRESS, ACCOUNT_MODULE_NAME.into());
+    let addr_arg = bcs::to_bytes(signer).expect("address can serialize");
+
     session
         .execute_function_bypass_visibility(
             &account_module_id,
@@ -122,6 +140,67 @@ pub fn check_nonce<G: GasMeter, MS: ModuleStorage>(
                 Error::nonce_invariant_violation(NonceChecking::IncrementNonceAlwaysSucceeds)
             }
         })?;
+
+    Ok(())
+}
+
+pub fn nonce_epilogue<MS: ModuleStorage>(
+    signer: &AccountAddress,
+    evm_nonces: HashMap<Address, u64>,
+    session: &mut Session,
+    traversal_context: &mut TraversalContext,
+    module_storage: &MS,
+) -> Result<(), Error> {
+    // These actions are unmetered because they happen after we have
+    // already charged for gas.
+    let mut gas_meter = UnmeteredGasMeter;
+
+    // The signer nonce must be incremented once regardless
+    // of what is in the EVM. This prevents replaying the
+    // current transaction.
+    increment_account_nonce(
+        signer,
+        session,
+        traversal_context,
+        &mut gas_meter,
+        module_storage,
+    )?;
+
+    for (address, nonce) in evm_nonces {
+        let address = address.to_move_address();
+        // If the Move noce does not match the EVM nonce then we need to update
+        if let Err(Error::InvalidTransaction(InvalidTransactionCause::IncorrectNonce {
+            expected,
+            given,
+        })) = check_nonce(
+            nonce,
+            &address,
+            session,
+            traversal_context,
+            &mut gas_meter,
+            module_storage,
+        ) {
+            if expected < given {
+                // If the Move nonce is lower than the EVM nonce then we
+                // must increament the Move nonce accordingly.
+                let diff = given - expected;
+                for _ in 0..diff {
+                    increment_account_nonce(
+                        &address,
+                        session,
+                        traversal_context,
+                        &mut gas_meter,
+                        module_storage,
+                    )?;
+                }
+            } else {
+                // It is impossible for the EVM nonce to be lower than
+                // the Move nonce because the EVM reads the Move nonce
+                // to fill the account info.
+                unreachable!("Move nonce <= EVM nonce");
+            }
+        }
+    }
 
     Ok(())
 }

--- a/execution/src/simulate.rs
+++ b/execution/src/simulate.rs
@@ -88,7 +88,7 @@ pub fn call_transaction(
     block_hash_lookup: &impl BlockHashLookup,
 ) -> umi_shared::error::Result<Vec<u8>> {
     let mut tx = NormalizedEthTransaction::from(request.clone());
-    if request.from.is_some() && request.nonce.is_none() {
+    if request.nonce.is_none() {
         tx.nonce = quick_get_nonce(&tx.signer.to_move_address(), state, storage_trie);
     }
     let tx_data = TransactionData::parse_from(&tx)?;

--- a/server/src/tests/evm_contracts/account_storage.rs
+++ b/server/src/tests/evm_contracts/account_storage.rs
@@ -114,6 +114,58 @@ async fn test_get_storage_at_evm_contract() -> anyhow::Result<()> {
     .await
 }
 
+#[tokio::test]
+async fn test_derive_evm_contract_address() -> anyhow::Result<()> {
+    // Test to check that the address of an EVM contract can be predicted
+    // using the return value from `eth_getTransactionCount` if the EVM-specific
+    // API endpoint is used.
+    TestContext::run(|mut ctx| async move {
+        let chain_id = ctx.genesis_config.chain_id;
+        let mut signer = Signer::random(chain_id);
+
+        // 1. Send some Move-only transactions
+        crate::tests::listing_apis::deploy_counter_contract(&mut ctx, &signer.sk).await;
+        crate::tests::listing_apis::call_counter_publish(&mut ctx, &signer.sk).await;
+
+        // Check the account nonce has changed and set the signer accordingly.
+        assert_eq!(ctx.get_nonce(signer.address()).await.unwrap(), 2);
+        signer.nonce = 2;
+
+        // 2. Switch to EVM endpoint
+        ctx.with_path("/evm");
+
+        // Here the account nonce is still 2 because the EVM is aware of Move nonce.
+        assert_eq!(ctx.get_nonce(signer.address()).await.unwrap(), 2);
+
+        // 3. Deploy EVM contract with nonce = 2
+        check_deployed_address(&mut signer, &mut ctx).await;
+
+        // 4. Deploy EVM contract with nonce = 3
+        check_deployed_address(&mut signer, &mut ctx).await;
+
+        // 5. Deploy EVM contract with nonce = 4
+        check_deployed_address(&mut signer, &mut ctx).await;
+
+        ctx.shutdown().await;
+        Ok(())
+    })
+    .await
+}
+
+// Confirms the EVM contract address can be predicted using `eth_getTransactionCount`.
+async fn check_deployed_address(signer: &mut Signer, ctx: &mut TestContext<'static>) -> Address {
+    let signer_address = signer.address();
+    let nonce = ctx.get_nonce(signer_address).await.unwrap();
+    signer.nonce = nonce;
+    let expected_contract_address = signer.address().create(nonce);
+    let tx = signer.deploy(evm_contract::BYTE_CODE);
+    let receipt = ctx.execute_transaction(tx).await.unwrap();
+    assert!(receipt.inner.inner.is_success());
+    let contract_address = receipt.inner.contract_address.unwrap();
+    assert_eq!(contract_address, expected_contract_address);
+    expected_contract_address
+}
+
 fn get_logged_height(receipt: &TransactionReceipt) -> U256 {
     let log = receipt.inner.inner.logs().first().unwrap();
     let AccountStorageEvents::TheHeight(height) =

--- a/server/src/tests/evm_contracts/mod.rs
+++ b/server/src/tests/evm_contracts/mod.rs
@@ -10,14 +10,46 @@ mod account_storage;
 mod block_env;
 mod blockhash;
 
+struct Signer {
+    chain_id: u64,
+    nonce: u64,
+    sk: PrivateKeySigner,
+}
+
+impl Signer {
+    fn random(chain_id: u64) -> Self {
+        Self {
+            chain_id,
+            nonce: 0,
+            sk: PrivateKeySigner::random(),
+        }
+    }
+
+    fn address(&self) -> Address {
+        self.sk.address()
+    }
+
+    fn deploy(&mut self, bytecode: &[u8]) -> TxEnvelope {
+        let result = sign_transaction(
+            self.chain_id,
+            TxKind::Create,
+            self.nonce,
+            bytecode.to_vec(),
+            &self.sk,
+        );
+        self.nonce += 1;
+        result
+    }
+}
+
 fn deploy_evm_contract(chain_id: u64, bytecode: &[u8]) -> TxEnvelope {
     let signer = PrivateKeySigner::random();
-    sign_transaction(chain_id, TxKind::Create, bytecode.to_vec(), &signer)
+    sign_transaction(chain_id, TxKind::Create, 0, bytecode.to_vec(), &signer)
 }
 
 fn call_contract(chain_id: u64, to: Address, evm_input: Vec<u8>) -> TxEnvelope {
     let signer = PrivateKeySigner::random();
-    sign_transaction(chain_id, TxKind::Call(to), evm_input, &signer)
+    sign_transaction(chain_id, TxKind::Call(to), 0, evm_input, &signer)
 }
 
 fn view_contract(to: Address, evm_input: Vec<u8>) -> TransactionRequest {
@@ -31,12 +63,13 @@ fn view_contract(to: Address, evm_input: Vec<u8>) -> TransactionRequest {
 fn sign_transaction(
     chain_id: u64,
     to: TxKind,
+    nonce: u64,
     input: Vec<u8>,
     signer: &PrivateKeySigner,
 ) -> TxEnvelope {
     let mut tx = TxEip1559 {
         chain_id,
-        nonce: 0,
+        nonce,
         gas_limit: u64::MAX,
         max_fee_per_gas: 0,
         max_priority_fee_per_gas: 0,

--- a/server/src/tests/listing_apis.rs
+++ b/server/src/tests/listing_apis.rs
@@ -180,7 +180,7 @@ async fn test_mv_list_resources() -> anyhow::Result<()> {
     .await
 }
 
-async fn deploy_counter_contract(
+pub async fn deploy_counter_contract(
     ctx: &mut TestContext<'static>,
     signer: &PrivateKeySigner,
 ) -> TransactionReceipt {
@@ -202,7 +202,7 @@ async fn deploy_counter_contract(
     ctx.execute_transaction(signed_tx).await.unwrap()
 }
 
-async fn call_counter_publish(
+pub async fn call_counter_publish(
     ctx: &mut TestContext<'static>,
     signer: &PrivateKeySigner,
 ) -> TransactionReceipt {

--- a/server/src/tests/test_context.rs
+++ b/server/src/tests/test_context.rs
@@ -128,6 +128,17 @@ impl TestContext<'static> {
         Ok(tx_hash)
     }
 
+    pub async fn get_nonce(&self, address: Address) -> anyhow::Result<u64> {
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "eth_getTransactionCount",
+            "params": [address]
+        });
+        let result: U256 = self.handle_request(&request).await?;
+        Ok(result.saturating_to())
+    }
+
     pub async fn get_transaction_receipt(
         &self,
         tx_hash: B256,


### PR DESCRIPTION
### Description
Closes #445 

### Changes
- EVM nonce is based on Move nonce when it exists 
- Move nonce is updated to reflect EVM nonce when there are changes in the EVM
- Move nonce changes happen at the end of the transaction 

### Testing
- New `test_derive_evm_contract_address`