### PR TITLE
Chore(evm): Remove TODO for populating access list

### DIFF
--- a/evm-ext/src/native_impl.rs
+++ b/evm-ext/src/native_impl.rs
@@ -310,8 +310,6 @@ fn construct_tx_env(
         // transaction
         nonce: 0,
         chain_id: None,
-        // TODO: could maybe construct something based on the values that
-        // have already been accessed in `context.traversal_context()`.
         access_list: AccessList::default(),
         gas_priority_fee: None,
         blob_hashes: Vec::new(),


### PR DESCRIPTION
### Description
Remove a TODO about populating the EVM access list. The TODO mentions trying to guess at which accounts had been accessed previously based on the `TraversalContext` available from `SafeNativeContext`. However, the `TraversalContext` only has to do with modules, not resources and modules are not helpful for the EVM native extension. Moreover, EVM account storage is now persisted separately from the rest of the Move state (the EVM account info is still a resource, but the indexed account storage has its own trie store). This means even if we could see which resources had already been loaded into memory, we would not load up any storage indexes, only account addresses (and even this is complicated by the fact that EVM bytecode is stored as separate resources from the account info). Finally, all of this would only amount to small gas savings in niche cases where users call the EVM multiple times in the same Move transaction.

In summary, I think it makes more sense to delete this TODO than to attempt to act on it. If we wanted to do something with EVM access lists then it would have to come explicitly [from the transaction](https://github.com/UmiNetwork/op-move/blob/b2781f5fb273302de767d086f7af9e8615d333b4/execution/src/transaction.rs#L307). That should be a separate issue though.

### Changes
- N/A

### Testing
- N/A
