### PR TITLE
Chore: delete TODO about channel size

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -92,7 +92,7 @@ pub fn defaults() -> DefaultLayer {
                 .into(),
             ),
         }),
-        max_buffered_commands: Some(1_000), // TODO: think about channel size bound
+        max_buffered_commands: Some(1_000),
     })
 }
 


### PR DESCRIPTION
### Description
Closes #42 

The impact of channel size on performance was investigated in #345. Also the `1000` number is now only a default value which can be changed via configuration. Therefore if we find this number to be non-optimal in the future then it is each to fix without any code change.

### Changes
- N/A

### Testing
- N/A
