### PR TITLE
feat(api): support engine API v4

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -4,6 +4,10 @@ edition.workspace = true
 name = "umi-api"
 version.workspace = true
 
+[features]
+default = []
+op-upgrade = []
+
 [lints]
 workspace = true
 

--- a/api/src/json_utils.rs
+++ b/api/src/json_utils.rs
@@ -66,3 +66,25 @@ where
         _ => Err(JsonRpcError::too_many_params_error(request)),
     }
 }
+
+pub fn parse_params_4<T1, T2, T3, T4>(
+    request: serde_json::Value,
+) -> Result<(T1, T2, T3, T4), JsonRpcError>
+where
+    T1: DeserializeOwned,
+    T2: DeserializeOwned,
+    T3: DeserializeOwned,
+    T4: DeserializeOwned,
+{
+    let params = get_params_list(&request);
+    match params {
+        [] | [_] | [_, _] | [_, _, _] => Err(JsonRpcError::not_enough_params_error(request)),
+        [a, b, c, d] => Ok((
+            deserialize(a)?,
+            deserialize(b)?,
+            deserialize(c)?,
+            deserialize(d)?,
+        )),
+        _ => Err(JsonRpcError::too_many_params_error(request)),
+    }
+}

--- a/api/src/method_name.rs
+++ b/api/src/method_name.rs
@@ -5,6 +5,8 @@ pub enum MethodName {
     ForkChoiceUpdatedV3,
     GetPayloadV3,
     NewPayloadV3,
+    GetPayloadV4,
+    NewPayloadV4,
     SendRawTransaction,
     ChainId,
     GetBalance,
@@ -37,7 +39,11 @@ impl MethodName {
     pub fn is_engine_api(&self) -> bool {
         matches!(
             self,
-            Self::ForkChoiceUpdatedV3 | Self::GetPayloadV3 | Self::NewPayloadV3
+            Self::ForkChoiceUpdatedV3
+                | Self::GetPayloadV3
+                | Self::NewPayloadV3
+                | Self::GetPayloadV4
+                | Self::NewPayloadV4
         )
     }
 }
@@ -50,6 +56,8 @@ impl FromStr for MethodName {
             "engine_forkchoiceUpdatedV3" => Self::ForkChoiceUpdatedV3,
             "engine_getPayloadV3" => Self::GetPayloadV3,
             "engine_newPayloadV3" => Self::NewPayloadV3,
+            "engine_getPayloadV4" => Self::GetPayloadV4,
+            "engine_newPayloadV4" => Self::NewPayloadV4,
 
             "eth_chainId" => Self::ChainId,
             "eth_getBalance" => Self::GetBalance,

--- a/api/src/methods/get_payload.rs
+++ b/api/src/methods/get_payload.rs
@@ -15,7 +15,6 @@ pub async fn execute_v3<'reader>(
     let payload_id: PayloadId = parse_params_1(request)?;
 
     // Spec: https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#specification-2
-    // unsupported fork if ts < cancun
     let response = match app.payload(payload_id.into())? {
         MaybePayloadResponse::Some(response) => response,
         MaybePayloadResponse::Delayed(mut rx) => {

--- a/api/src/request.rs
+++ b/api/src/request.rs
@@ -99,6 +99,11 @@ where
         }
         GetPayloadV3 => get_payload::execute_v3(request, app).await,
         NewPayloadV3 => new_payload::execute_v3(request, app).await,
+        // Despite having a new field in V4 (execution requests), it's always empty and `op-geth`
+        // itself falls back to V3 here
+        GetPayloadV4 => get_payload::execute_v3(request, app).await,
+        NewPayloadV4 => new_payload::execute_v4(request, app).await,
+
         SendRawTransaction => {
             send_raw_transaction::execute(request, queue, serialization_tag).await
         }


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
First step toward OP bump support.
<!-- Fixes #123 -->

### Changes
<!-- Key changes -->
- Most changes to `newPayload` processing
- `getPayload` just falls back to V3 like `op-geth`
- feature gated one format check that interferes with old logic