### PR TITLE
Fix(API): Return hex string for byte arrays

### DIFF
--- a/api/src/methods/call.rs
+++ b/api/src/methods/call.rs
@@ -2,6 +2,7 @@ use {
     crate::{json_utils::parse_params_2, jsonrpc::JsonRpcError, request::SerializationKind},
     alloy::{
         eips::BlockNumberOrTag,
+        primitives::Bytes,
         rpc::types::{TransactionInput, TransactionRequest},
     },
     umi_app::{ApplicationReader, Dependencies},
@@ -25,7 +26,7 @@ pub async fn execute<'reader>(
         }
     }
 
-    let response = app.call(transaction, block_number)?;
+    let response = Bytes::from(app.call(transaction, block_number)?);
 
     Ok(serde_json::to_value(response).expect("Must be able to JSON-serialize response"))
 }

--- a/api/src/methods/call.rs
+++ b/api/src/methods/call.rs
@@ -127,7 +127,7 @@ mod tests {
 
             state_channel.reserve_many(10).await.unwrap();
 
-            let expected_response = serde_json::json!([1, 1, 0]);
+            let expected_response: serde_json::Value = serde_json::from_str(r#""0x010100""#).unwrap();
             let actual_response = execute(request, &reader, SerializationKind::Bcs).await.unwrap();
 
             assert_eq!(actual_response, expected_response);

--- a/server/src/tests/evm_contracts/account_storage.rs
+++ b/server/src/tests/evm_contracts/account_storage.rs
@@ -65,13 +65,13 @@ async fn test_storage_evm_contract() -> anyhow::Result<()> {
             .eth_call(view_request.clone(), BlockNumberOrTag::Number(2))
             .await
             .unwrap();
-        assert_eq!(U256::from_be_slice(&height_2), U256::from(2));
+        assert_eq!(height_2, format!("0x{:064x}", 2));
 
         let height_3 = ctx
             .eth_call(view_request, BlockNumberOrTag::Number(3))
             .await
             .unwrap();
-        assert_eq!(U256::from_be_slice(&height_3), U256::from(3));
+        assert_eq!(height_3, format!("0x{:064x}", 3));
 
         ctx.shutdown().await;
 

--- a/server/src/tests/test_context.rs
+++ b/server/src/tests/test_context.rs
@@ -159,7 +159,7 @@ impl TestContext<'static> {
         &self,
         tx: TransactionRequest,
         block: BlockNumberOrTag,
-    ) -> anyhow::Result<Vec<u8>> {
+    ) -> anyhow::Result<String> {
         let request = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 11,


### PR DESCRIPTION
### Description
Change the `eth_call` response to hex string instead of byte array, since especially EVM SDKs expect this response.

### Changes
- Encode `eth_call` response into hex string

### Testing
Tested on a sample contract. Before the SDK would fail with:
```
TypeError: invalid BytesLike value (argument="value", value=[ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 ], code=INVALID_ARGUMENT, version=6.14.4)
```
Now it parses the response correctly as a big number:
```
Count: 1n
```