### PR TITLE
fix(engine): harden payload handling

### DIFF
--- a/api/src/methods/call.rs
+++ b/api/src/methods/call.rs
@@ -45,7 +45,7 @@ mod tests {
         std::str::FromStr,
         test_case::test_case,
         tokio::sync::mpsc,
-        umi_app::{Command, CommandActor},
+        umi_app::{Command, CommandActor, PayloadForExecution},
         umi_shared::primitives::U64,
     };
 
@@ -83,7 +83,7 @@ mod tests {
         }
     }
 
-    #[test_case("0x2")]
+    #[test_case("0x3")]
     #[test_case("0x12a")]
     #[test_case("latest")]
     #[test_case("pending")]
@@ -95,15 +95,18 @@ mod tests {
 
         umi_app::run_with_actor(state_actor, async move {
             // Add funds to the account to deploy the `counter` contract
-            deposit_eth("0x8fd379246834eac74b8419ffda202cf8051f7a03", &state_channel).await;
-            deploy_contract(Bytes::from_hex("0101fd01a11ceb0b0600000009010002020204030614051a0e07283d0865200a8501050c8a01490dd3010200000001080000020001000003000200000400030000050403000105010101030002060c0301070307636f756e74657207436f756e7465720e636f756e7465725f657869737473096765745f636f756e7409696e6372656d656e74077075626c69736801690000000000000000000000008fd379246834eac74b8419ffda202cf8051f7a0300020106030001000003030b00290002010100010003050b002b00100014020201040100050b0b002a000f000c010a0114060100000000000000160b0115020301040003050b000b0112002d0002000000").unwrap(), &state_channel).await;
+            deposit_eth("0x8fd379246834eac74b8419ffda202cf8051f7a03", 1, &state_channel).await;
+            deploy_contract(Bytes::from_hex("0101fd01a11ceb0b0600000009010002020204030614051a0e07283d0865200a8501050c8a01490dd3010200000001080000020001000003000200000400030000050403000105010101030002060c0301070307636f756e74657207436f756e7465720e636f756e7465725f657869737473096765745f636f756e7409696e6372656d656e74077075626c69736801690000000000000000000000008fd379246834eac74b8419ffda202cf8051f7a0300020106030001000003030b00290002010100010003050b002b00100014020201040100050b0b002a000f000c010a0114060100000000000000160b0115020301040003050b000b0112002d0002000000").unwrap(), 2, &state_channel).await;
             state_channel.reserve_many(10).await.unwrap();
 
-          for i in 1..=300 {
+          for i in 3..=302 {
               // Create and submit a block to advance the chain
               // This will populate the block hash cache progressively
             let msg = Command::StartBlockBuild {
-                payload_attributes: Default::default(),
+                payload_attributes: PayloadForExecution {
+                        timestamp: U64::from(i),
+                        ..Default::default()
+                    },
                 payload_id: U64::from(i),
             };
               state_channel.send(msg).await.unwrap();
@@ -134,7 +137,7 @@ mod tests {
         }).await;
     }
 
-    #[test_case("0x2")]
+    #[test_case("0x3")]
     #[test_case("0x12a")]
     #[test_case("latest")]
     #[test_case("pending")]
@@ -146,14 +149,17 @@ mod tests {
 
         umi_app::run_with_actor(state_actor, async move {
             // Add funds to the account to deploy the `counter` contract
-            deposit_eth("0x8fd379246834eac74b8419ffda202cf8051f7a03", &state_channel).await;
-            deploy_contract(Bytes::from_hex("0101fd01a11ceb0b0600000009010002020204030614051a0e07283d0865200a8501050c8a01490dd3010200000001080000020001000003000200000400030000050403000105010101030002060c0301070307636f756e74657207436f756e7465720e636f756e7465725f657869737473096765745f636f756e7409696e6372656d656e74077075626c69736801690000000000000000000000008fd379246834eac74b8419ffda202cf8051f7a0300020106030001000003030b00290002010100010003050b002b00100014020201040100050b0b002a000f000c010a0114060100000000000000160b0115020301040003050b000b0112002d0002000000").unwrap(), &state_channel).await;
+            deposit_eth("0x8fd379246834eac74b8419ffda202cf8051f7a03", 1, &state_channel).await;
+            deploy_contract(Bytes::from_hex("0101fd01a11ceb0b0600000009010002020204030614051a0e07283d0865200a8501050c8a01490dd3010200000001080000020001000003000200000400030000050403000105010101030002060c0301070307636f756e74657207436f756e7465720e636f756e7465725f657869737473096765745f636f756e7409696e6372656d656e74077075626c69736801690000000000000000000000008fd379246834eac74b8419ffda202cf8051f7a0300020106030001000003030b00290002010100010003050b002b00100014020201040100050b0b002a000f000c010a0114060100000000000000160b0115020301040003050b000b0112002d0002000000").unwrap(), 2, &state_channel).await;
 
-          for i in 1..=300 {
+          for i in 3..=302 {
               // Create and submit a block to advance the chain
               // This will populate the block hash cache progressively
             let msg = Command::StartBlockBuild {
-                payload_attributes: Default::default(),
+                payload_attributes: PayloadForExecution {
+                        timestamp: U64::from(i),
+                        ..Default::default()
+                    },
                 payload_id: U64::from(i),
             };
               state_channel.send(msg).await.unwrap();

--- a/api/src/methods/estimate_gas.rs
+++ b/api/src/methods/estimate_gas.rs
@@ -61,7 +61,7 @@ mod tests {
         std::str::FromStr,
         test_case::test_case,
         tokio::sync::mpsc,
-        umi_app::{Command, CommandActor},
+        umi_app::{Command, CommandActor, PayloadForExecution},
         umi_shared::primitives::U64,
     };
 
@@ -111,7 +111,7 @@ mod tests {
         }
     }
 
-    #[test_case("0x1")]
+    #[test_case("0x2")]
     #[test_case("0x120")]
     #[test_case("latest")]
     #[test_case("pending")]
@@ -122,7 +122,7 @@ mod tests {
         let state_actor = CommandActor::new(rx, &mut app);
 
         umi_app::run_with_actor(state_actor, async move {
-            deposit_eth("0x8fd379246834eac74b8419ffda202cf8051f7a03", &state_channel).await;
+            deposit_eth("0x8fd379246834eac74b8419ffda202cf8051f7a03", 1, &state_channel).await;
 
             let request: serde_json::Value = serde_json::json!({
                 "jsonrpc": "2.0",
@@ -139,15 +139,18 @@ mod tests {
 
             state_channel.reserve_many(10).await.unwrap();
 
-          for i in 1..=300 {
+          for i in 2..=301 {
               // Create and submit a block to advance the chain
               // This will populate the block hash cache progressively
-            let msg = Command::StartBlockBuild {
-                payload_attributes: Default::default(),
-                payload_id: U64::from(i),
-            };
-              state_channel.send(msg).await.unwrap();
-             state_channel.reserve_many(10).await.unwrap();
+                let msg = Command::StartBlockBuild {
+                    payload_attributes: PayloadForExecution {
+                            timestamp: U64::from(i),
+                            ..Default::default()
+                        },
+                    payload_id: U64::from(i),
+                };
+                state_channel.send(msg).await.unwrap();
+                state_channel.reserve_many(10).await.unwrap();
           }
             let expected_response: serde_json::Value = serde_json::from_str(r#""0x63ec""#).unwrap();
             let actual_response = execute(request, &reader, SerializationKind::Bcs).await.unwrap();

--- a/api/src/methods/forkchoice_updated.rs
+++ b/api/src/methods/forkchoice_updated.rs
@@ -70,11 +70,16 @@ async fn inner_execute_v3<'reader>(
     let payload_id = if let Some(attrs) = payload_attributes {
         let payload_id = payload_id_generator
             .new_payload_id(attrs.to_payload_id_input(&forkchoice_state.head_block_hash));
-        let msg = Command::StartBlockBuild {
-            payload_attributes: attrs,
-            payload_id,
-        };
-        queue.send(msg).await;
+        if matches!(
+            app.payload(payload_id)?,
+            umi_blockchain::payload::MaybePayloadResponse::Unknown
+        ) {
+            let msg = Command::StartBlockBuild {
+                payload_attributes: attrs,
+                payload_id,
+            };
+            queue.send(msg).await;
+        }
         Some(PayloadId(payload_id))
     } else {
         None

--- a/api/src/methods/get_block_by_number.rs
+++ b/api/src/methods/get_block_by_number.rs
@@ -24,7 +24,7 @@ mod tests {
         alloy::eips::BlockNumberOrTag::{self, *},
         test_case::test_case,
         tokio::sync::mpsc,
-        umi_app::{Command, CommandActor, TestDependencies},
+        umi_app::{Command, CommandActor, PayloadForExecution, TestDependencies},
         umi_shared::primitives::U64,
     };
 
@@ -110,7 +110,10 @@ mod tests {
 
             // Create a block, so the block height becomes 1
             let msg = Command::StartBlockBuild {
-                payload_attributes: Default::default(),
+                payload_attributes: PayloadForExecution {
+                    timestamp: U64::from(1),
+                    ..Default::default()
+                },
                 payload_id: U64::from(0x03421ee50df45cacu64),
             };
             state_channel.send(msg).await.unwrap();
@@ -138,7 +141,10 @@ mod tests {
 
         umi_app::run_with_actor(state, async move {
             let msg = Command::StartBlockBuild {
-                payload_attributes: Default::default(),
+                payload_attributes: PayloadForExecution {
+                    timestamp: U64::from(1),
+                    ..Default::default()
+                },
                 payload_id: U64::from(0x03421ee50df45cacu64),
             };
             state_channel.send(msg).await.unwrap();

--- a/api/src/methods/mod.rs
+++ b/api/src/methods/mod.rs
@@ -160,7 +160,7 @@ pub mod tests {
         )
     }
 
-    pub async fn deposit_eth(to: &str, channel: &Sender<Command>) {
+    pub async fn deposit_eth(to: &str, block_num: u64, channel: &Sender<Command>) {
         let to = Address::from_hex(to).unwrap();
         let amount = parse_ether("1").unwrap();
         let tx = NormalizedExtendedTxEnvelope::DepositedTx(Sealed::new(TxDeposit {
@@ -179,6 +179,7 @@ pub mod tests {
         let payload_attributes = Payload {
             gas_limit: U64::MAX,
             transactions: vec![encoded.into()],
+            timestamp: U64::from(block_num),
             ..Default::default()
         };
 
@@ -189,7 +190,7 @@ pub mod tests {
         channel.send(msg).await.unwrap();
     }
 
-    pub async fn deploy_contract(contract_bytes: Bytes, channel: &Sender<Command>) {
+    pub async fn deploy_contract(contract_bytes: Bytes, block_num: u64, channel: &Sender<Command>) {
         let mut tx = TxEip1559 {
             chain_id: CHAIN_ID,
             nonce: 0,
@@ -212,6 +213,7 @@ pub mod tests {
         let payload_attributes = Payload {
             gas_limit: U64::MAX,
             transactions: vec![encoded.into()],
+            timestamp: U64::from(block_num),
             ..Default::default()
         };
 

--- a/app/src/command.rs
+++ b/app/src/command.rs
@@ -52,6 +52,7 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             return Ok(());
         }
         let in_progress_payloads = self.payload_queries.get_in_progress();
+        // If there is a job with this id already present, nothing to do
         if in_progress_payloads.start_id(id).is_err() {
             return Ok(());
         }
@@ -60,9 +61,9 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
         let no_tx_pool = attributes.no_tx_pool.unwrap_or(false);
 
         let transactions = if no_tx_pool {
-            // Though it should be a rare event without follower nodes, `op-node` can demand
-            // to rebuild a block deterministically from payload attributes only. We log it
-            // as a rare event for diagnostic purposes.
+            // Though it is a relatively rare event without follower nodes, `op-node` can demand
+            // to rebuild a block deterministically from payload attributes only. This also happens
+            // when an L2 reorg is triggered. We log it for diagnostic purposes.
             tracing::warn!(
                 "Building from payload attributes only, with no mempool txs: {attributes:?}"
             );
@@ -89,6 +90,7 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| {
                 tracing::error!("Failure during `start_block_build`. Receipt queries failed: {e:?}");
+                in_progress_payloads.abort_id(&id);
                 UnrecoverableAppFailure
             })?;
 
@@ -97,9 +99,21 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             .latest(&self.storage)
             .map_err(|e| {
                 tracing::error!("Failure during `start_block_build`. Failed to get latest block from block repository: {e:?}");
+                in_progress_payloads.abort_id(&id);
                 UnrecoverableAppFailure
             })?
             .expect("Block repository is non-empty (must always at least contain genesis)");
+        // TODO: also check block time (preferrably dynamically from a config) and
+        // ensure build timeout relative to it
+        if parent.block.header.timestamp >= attributes.timestamp.as_limbs()[0] {
+            tracing::error!(
+                "Encountered non-monotonic timestamp. Parent block had {}, received {} in attributes",
+                parent.block.header.timestamp,
+                attributes.timestamp
+            );
+            in_progress_payloads.abort_id(&id);
+            return Ok(());
+        }
         #[cfg(feature = "op-upgrade")]
         if let Some(params) = &attributes.eip1559_params {
             self.gas_fee.set_parameters_from_attrs(params);
@@ -116,11 +130,16 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             prev_randao: attributes.prev_randao,
             chain_id: self.genesis_config.chain_id,
         };
-        let (execution_outcome, receipts) = self.execute_transactions(
-            new_transactions.clone().into_iter(),
-            base_fee,
-            &header_for_execution,
-        )?;
+        let (execution_outcome, receipts) = self
+            .execute_transactions(
+                new_transactions.clone().into_iter(),
+                base_fee,
+                &header_for_execution,
+            )
+            .map_err(|_| {
+                in_progress_payloads.abort_id(&id);
+                UnrecoverableAppFailure
+            })?;
 
         let transactions_root = alloy_trie::root::ordered_trie_root(&new_transactions);
 
@@ -150,6 +169,7 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
                 tracing::error!(
                     "Failure during `start_block_build`. Failed to get L2ToL1MessagePasser account from storage: {e:?}"
                 );
+                in_progress_payloads.abort_id(&id);
                 UnrecoverableAppFailure
             })?.expect("L2ToL1MessagePasser is deployed at genesis");
             Some(message_passer_account.inner.storage_root)
@@ -213,6 +233,7 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
                 tracing::error!(
                     "Failure during `start_block_build`. Failed to write receipts: {e:?}"
                 );
+                in_progress_payloads.abort_id(&id);
                 UnrecoverableAppFailure
             })?;
 
@@ -222,6 +243,7 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
                 tracing::error!(
                     "Failure during `start_block_build`. Failed to write transactions: {e:?}"
                 );
+                in_progress_payloads.abort_id(&id);
                 UnrecoverableAppFailure
             })?;
 
@@ -232,6 +254,7 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
                 tracing::error!(
                     "Failure during `start_block_build`. Failed to write produced block: {e:?}"
                 );
+                in_progress_payloads.abort_id(&id);
                 UnrecoverableAppFailure
             })?;
 
@@ -239,6 +262,7 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             tracing::error!(
                 "Failure during `start_block_build`. `on_payload` callback failed: {e:?}"
             );
+            in_progress_payloads.abort_id(&id);
             UnrecoverableAppFailure
         })?;
 
@@ -251,6 +275,7 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
                 .try_for_each(|tx| {
                     let tx = tx.as_canonical().ok_or_else(|| {
                         tracing::error!("Failure during `start_block_build`. Deposit transaction encountered outside of pyaload attributes in mempool removal.");
+                        in_progress_payloads.abort_id(&id);
                         UnrecoverableAppFailure
                     })?;
                     self.mem_pool.remove_by_nonce(tx.nonce, tx.signer);

--- a/app/src/command.rs
+++ b/app/src/command.rs
@@ -90,7 +90,6 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| {
                 tracing::error!("Failure during `start_block_build`. Receipt queries failed: {e:?}");
-                in_progress_payloads.abort_id(&id);
                 UnrecoverableAppFailure
             })?;
 
@@ -99,7 +98,6 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             .latest(&self.storage)
             .map_err(|e| {
                 tracing::error!("Failure during `start_block_build`. Failed to get latest block from block repository: {e:?}");
-                in_progress_payloads.abort_id(&id);
                 UnrecoverableAppFailure
             })?
             .expect("Block repository is non-empty (must always at least contain genesis)");
@@ -130,16 +128,11 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             prev_randao: attributes.prev_randao,
             chain_id: self.genesis_config.chain_id,
         };
-        let (execution_outcome, receipts) = self
-            .execute_transactions(
-                new_transactions.clone().into_iter(),
-                base_fee,
-                &header_for_execution,
-            )
-            .map_err(|_| {
-                in_progress_payloads.abort_id(&id);
-                UnrecoverableAppFailure
-            })?;
+        let (execution_outcome, receipts) = self.execute_transactions(
+            new_transactions.clone().into_iter(),
+            base_fee,
+            &header_for_execution,
+        )?;
 
         let transactions_root = alloy_trie::root::ordered_trie_root(&new_transactions);
 
@@ -169,7 +162,6 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
                 tracing::error!(
                     "Failure during `start_block_build`. Failed to get L2ToL1MessagePasser account from storage: {e:?}"
                 );
-                in_progress_payloads.abort_id(&id);
                 UnrecoverableAppFailure
             })?.expect("L2ToL1MessagePasser is deployed at genesis");
             Some(message_passer_account.inner.storage_root)
@@ -233,7 +225,6 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
                 tracing::error!(
                     "Failure during `start_block_build`. Failed to write receipts: {e:?}"
                 );
-                in_progress_payloads.abort_id(&id);
                 UnrecoverableAppFailure
             })?;
 
@@ -243,7 +234,6 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
                 tracing::error!(
                     "Failure during `start_block_build`. Failed to write transactions: {e:?}"
                 );
-                in_progress_payloads.abort_id(&id);
                 UnrecoverableAppFailure
             })?;
 
@@ -254,7 +244,6 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
                 tracing::error!(
                     "Failure during `start_block_build`. Failed to write produced block: {e:?}"
                 );
-                in_progress_payloads.abort_id(&id);
                 UnrecoverableAppFailure
             })?;
 
@@ -262,7 +251,6 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
             tracing::error!(
                 "Failure during `start_block_build`. `on_payload` callback failed: {e:?}"
             );
-            in_progress_payloads.abort_id(&id);
             UnrecoverableAppFailure
         })?;
 
@@ -274,8 +262,7 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
                 .skip(attributes_txs_len)
                 .try_for_each(|tx| {
                     let tx = tx.as_canonical().ok_or_else(|| {
-                        tracing::error!("Failure during `start_block_build`. Deposit transaction encountered outside of pyaload attributes in mempool removal.");
-                        in_progress_payloads.abort_id(&id);
+                        tracing::error!("Failure during `start_block_build`. Deposit transaction encountered outside of payload attributes in mempool removal.");
                         UnrecoverableAppFailure
                     })?;
                     self.mem_pool.remove_by_nonce(tx.nonce, tx.signer);

--- a/app/src/tests.rs
+++ b/app/src/tests.rs
@@ -459,7 +459,10 @@ fn test_fetched_balances_are_updated_after_transfer_of_funds() {
 
     app.add_transaction(tx);
     app.start_block_build(
-        PayloadForExecution::default(),
+        PayloadForExecution {
+            timestamp: U64::from(1),
+            ..PayloadForExecution::default()
+        },
         U64::from(0x03421ee50df45cacu64),
     )
     .unwrap();
@@ -486,7 +489,10 @@ fn test_fetched_nonces_are_updated_after_executing_transaction() {
 
     app.add_transaction(tx);
     app.start_block_build(
-        PayloadForExecution::default(),
+        PayloadForExecution {
+            timestamp: U64::from(1),
+            ..PayloadForExecution::default()
+        },
         U64::from(0x03421ee50df45cacu64),
     )
     .unwrap();
@@ -514,8 +520,14 @@ fn test_one_payload_can_be_fetched_repeatedly() {
 
     let payload_id = U64::from(0x03421ee50df45cacu64);
 
-    app.start_block_build(PayloadForExecution::default(), payload_id)
-        .unwrap();
+    app.start_block_build(
+        PayloadForExecution {
+            timestamp: U64::from(1),
+            ..PayloadForExecution::default()
+        },
+        payload_id,
+    )
+    .unwrap();
 
     let expected_payload = reader.payload(payload_id).unwrap().unwrap();
     let actual_payload = reader.payload(payload_id).unwrap().unwrap();
@@ -537,6 +549,7 @@ fn test_older_payload_can_be_fetched_again_successfully() {
 
     app.start_block_build(
         Payload {
+            timestamp: U64::from(1),
             gas_limit: U64::MAX,
             ..Default::default()
         }
@@ -556,7 +569,7 @@ fn test_older_payload_can_be_fetched_again_successfully() {
 
     app.start_block_build(
         Payload {
-            timestamp: U64::from(1u64),
+            timestamp: U64::from(2),
             gas_limit: U64::MAX,
             ..Default::default()
         }
@@ -590,8 +603,14 @@ fn test_txs_from_one_account_have_proper_nonce_ordering() {
 
     let payload_id = U64::from(0x03421ee50df45cacu64);
 
-    app.start_block_build(PayloadForExecution::default(), payload_id)
-        .unwrap();
+    app.start_block_build(
+        PayloadForExecution {
+            timestamp: U64::from(1),
+            ..PayloadForExecution::default()
+        },
+        payload_id,
+    )
+    .unwrap();
 
     for (i, tx_hash) in tx_hashes.iter().enumerate() {
         // Get receipt for this transaction
@@ -702,8 +721,14 @@ fn test_fee_history_eip1559_fields() {
     let (reader, mut app) =
         create_app_with_fake_queries(EVM_ADDRESS.to_move_address(), U256::from(10), 0, 1);
 
-    app.start_block_build(PayloadForExecution::default(), U64::from(1))
-        .unwrap();
+    app.start_block_build(
+        PayloadForExecution {
+            timestamp: U64::from(1),
+            ..PayloadForExecution::default()
+        },
+        U64::from(1),
+    )
+    .unwrap();
 
     let result = reader.fee_history(1, Latest, None);
     assert!(result.is_ok());
@@ -734,6 +759,7 @@ fn test_fee_history_empty_vs_full_blocks(num_txs: usize, expect_zero_ratio: bool
 
     let payload = Payload {
         gas_limit: U64::from(1_000_000),
+        timestamp: U64::from(1),
         ..Default::default()
     };
     app.start_block_build(payload.try_into().unwrap(), U64::from(1))
@@ -771,6 +797,7 @@ fn test_fee_history_percentile_calculations(
     app.start_block_build(
         Payload {
             gas_limit: U64::from(1_000_000),
+            timestamp: U64::from(1),
             ..Default::default()
         }
         .try_into()
@@ -855,6 +882,7 @@ fn test_fee_history_boundary_percentiles() {
     app.start_block_build(
         Payload {
             gas_limit: U64::from(1_000_000),
+            timestamp: U64::from(1),
             ..Default::default()
         }
         .try_into()
@@ -894,6 +922,7 @@ fn test_max_priority_fee_low_congestion() {
     app.start_block_build(
         Payload {
             gas_limit: U64::from(1_000_000), // still well within the block limits
+            timestamp: U64::from(1),
             ..Default::default()
         }
         .try_into()
@@ -927,6 +956,7 @@ fn test_max_priority_fee_high_congestion() {
     app.start_block_build(
         Payload {
             gas_limit: U64::from(100_000),
+            timestamp: U64::from(1),
             ..Default::default()
         }
         .try_into()
@@ -961,6 +991,7 @@ fn test_gas_price_high_max_fee() {
     app.start_block_build(
         Payload {
             gas_limit: U64::from(100_000),
+            timestamp: U64::from(1),
             ..Default::default()
         }
         .try_into()
@@ -988,6 +1019,7 @@ fn test_gas_price_vs_max_priority_fee_difference() {
     app.start_block_build(
         Payload {
             gas_limit: U64::from(1_000_000),
+            timestamp: U64::from(1),
             ..Default::default()
         }
         .try_into()
@@ -1053,6 +1085,7 @@ fn test_no_tx_pool_does_not_affect_mempool() {
     let payload_attributes = PayloadForExecution {
         no_tx_pool: Some(true),
         transactions: vec![payload_tx.clone().into()],
+        timestamp: U64::from(1),
         ..Default::default()
     };
     let payload_id = U64::from(1);

--- a/blockchain/src/payload/read.rs
+++ b/blockchain/src/payload/read.rs
@@ -156,6 +156,16 @@ impl InProgressPayloads {
         }
     }
 
+    /// Abort a build job: drop its sender so all receivers see `Err(RecvError::Closed)`.
+    /// Returns true if a job existed and was removed.
+    pub fn abort_id(&self, id: &PayloadId) -> bool {
+        self.inner
+            .write()
+            .expect("Lock is not poisoned")
+            .remove(id)
+            .is_some()
+    }
+
     pub fn finish_id(
         &self,
         block: ExtendedBlock,


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
Some minute changes to the way payload attributes are handled around timestamps and in progress jobs.

Fixes #508.
<!-- Fixes #123 -->

### Changes
<!-- Key changes -->
- Ensure monotonic timestamp relative to parent
- Avoid sending block build commands for existing payloads
- Remove the respective payload from in progress map if the block build fails

### Notes
<!-- Additional info -->
When going through our main loop again, I noticed two very itchy issues that we never addressed, so I'll try to pick it up next:
* The actor is never automatically restarted on a failed built, but left hanging indefinitely, whereas we could have a supervisor of sorts to do just that
* There's no transactionality to the changes done during block build: e.g. if some DB access fails on receipt write, the Move/EVM changes would have already been committed and there's no rollback or anything, leaving the state inconsistent. A more correct approach would be to batch all changes together and roll back on any failure