### PR TITLE
refactor(server): have dedicated runtimes for auth and http routes

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -53,6 +53,12 @@ pub struct ServerLog<'a> {
     pub op_move_response: &'a JsonRpcResponse,
 }
 
+#[derive(Debug)]
+pub struct ServerRuntimes<'a> {
+    pub http: &'a tokio::runtime::Runtime,
+    pub auth: &'a tokio::runtime::Runtime,
+}
+
 pub fn defaults() -> DefaultLayer {
     let default_genesis_config = GenesisConfig::default();
     let umi_root_path = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -108,6 +114,7 @@ pub fn set_global_tracing_subscriber() {
         .add_directive("alloy=info".parse().expect("Is valid directive"));
 
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_thread_names(true)
         .with_env_filter(filter)
         .with_ansi(false)
         .with_span_events(FmtSpan::FULL)
@@ -115,7 +122,7 @@ pub fn set_global_tracing_subscriber() {
     tracing::subscriber::set_global_default(subscriber).expect("Failed to set tracing subscriber");
 }
 
-pub async fn run(args: Config) {
+pub async fn run_with_runtimes(args: Config, rts: ServerRuntimes<'_>) {
     let genesis_config = GenesisConfig::try_new(
         args.genesis.chain_id,
         args.genesis.initial_state_root,
@@ -141,20 +148,36 @@ pub async fn run(args: Config) {
     umi_app::run(
         (reader, app),
         args.max_buffered_commands,
-        |queue, reader| {
-            tokio::spawn(async move {
-                tokio::join!(
-                    serve(args.http.addr, &queue, &reader, &allow::http, None),
-                    serve(args.auth.addr, &queue, &reader, &allow::auth, Some(jwt)),
-                );
-            })
+        |queue, reader| async move {
+            let queue_http = queue.clone();
+            let reader_http = reader.clone();
+            let addr_http = args.http.addr;
+
+            let http = rts.http.spawn(serve(
+                addr_http,
+                &queue_http,
+                &reader_http,
+                &allow::http,
+                None,
+            ));
+
+            let queue_auth = queue.clone();
+            let reader_auth = reader.clone();
+            let addr_auth = args.auth.addr;
+
+            let auth = rts.auth.spawn(serve(
+                addr_auth,
+                &queue_auth,
+                &reader_auth,
+                &allow::auth,
+                Some(jwt),
+            ));
+
+            queue.shutdown_listener().await;
+            let _ = (http.await, auth.await);
         },
     )
     .await
-    .inspect_err(|e| {
-        tracing::error!("Failed to join spawned server task: {e:?}");
-    })
-    .ok();
 }
 
 pub fn server_filter(
@@ -200,7 +223,7 @@ fn serve(
     reader: &ApplicationReader<'static, dependency::ReaderDependency>,
     is_allowed: &'static (impl Fn(&MethodName) -> bool + Send + Sync),
     jwt: Option<DecodingKey>,
-) -> impl Future<Output = ()> {
+) -> impl Future<Output = ()> + Send + 'static {
     let route = server_filter(queue, reader, is_allowed, jwt);
     warp::serve(route)
         .bind_with_graceful_shutdown(addr, queue.shutdown_listener())

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -5,6 +5,7 @@ use {
     std::{
         future::Future,
         net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+        num::NonZeroUsize,
         path::Path,
         time::SystemTime,
     },
@@ -103,6 +104,20 @@ pub fn defaults() -> DefaultLayer {
 }
 
 const JWT_VALID_DURATION_IN_SECS: u64 = 60;
+
+pub fn set_workers_count() -> (usize, usize) {
+    let core_count = std::thread::available_parallelism()
+        .map(NonZeroUsize::get)
+        .unwrap_or(1);
+    // Leaving some leeway to avoid saturation
+    let reserve = core_count.saturating_div(8).max(1);
+    let usable = core_count.saturating_sub(reserve);
+
+    let auth_ratio: f32 = 0.30;
+    let auth_workers = (((usable as f32) * auth_ratio).round() as usize).clamp(2, usable - 2);
+    let http_workers = usable.saturating_sub(auth_workers).max(2);
+    (auth_workers, http_workers)
+}
 
 pub fn set_global_tracing_subscriber() {
     // TODO: config options for logging (debug level, output to file, etc)

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -113,6 +113,10 @@ pub fn set_workers_count() -> (usize, usize) {
     let reserve = core_count.saturating_div(8).max(1);
     let usable = core_count.saturating_sub(reserve);
 
+    if usable < 4 {
+        return (1, 1);
+    }
+
     let auth_ratio: f32 = 0.30;
     let auth_workers = (((usable as f32) * auth_ratio).round() as usize).clamp(2, usable - 2);
     let http_workers = usable.saturating_sub(auth_workers).max(2);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -13,15 +13,18 @@ fn main() {
         .expect("Must build config to run app");
 
     umi_server::set_global_tracing_subscriber();
+
+    let (auth_count, http_count) = umi_server::set_workers_count();
+
     let http_rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(10)
+        .worker_threads(http_count)
         .thread_name("rt-http")
         .enable_all()
         .build()
         .expect("Must build http runtime to run app");
 
     let auth_rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(4)
+        .worker_threads(auth_count)
         .thread_name("rt-auth")
         .enable_all()
         .build()

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,10 +1,9 @@
 use {
-    umi_server::defaults,
+    umi_server::{defaults, ServerRuntimes},
     umi_server_args::{CliLayer, ConfigBuilder, EnvLayer, FileLayer},
 };
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let args = ConfigBuilder::new()
         .layer(defaults())
         .layer(FileLayer::toml())
@@ -14,5 +13,25 @@ async fn main() {
         .expect("Must build config to run app");
 
     umi_server::set_global_tracing_subscriber();
-    umi_server::run(args).await;
+    let http_rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(10)
+        .thread_name("rt-http")
+        .enable_all()
+        .build()
+        .expect("Must build http runtime to run app");
+
+    let auth_rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_name("rt-auth")
+        .enable_all()
+        .build()
+        .expect("Must build auth runtime to run app");
+
+    http_rt.block_on(umi_server::run_with_runtimes(
+        args,
+        ServerRuntimes {
+            http: &http_rt,
+            auth: &auth_rt,
+        },
+    ));
 }


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
This goes along a similar vein as #512, but a cleaner solution of having dedicated runtimes for auth and http respectively.
<!-- Fixes #123 -->

### Changes
<!-- Key changes -->
- Serve futures are spawned separately on different RTs