### PR TITLE
build(docker): Start from the workspace rust toolchain for `op-move`

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,7 +48,7 @@ jobs:
 
       # Stage 1: Build and push base images first
       - name: Build base images
-        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml build op-move geth
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml build --build-arg RUST_TOOLCHAIN=$(cat rust-toolchain) op-move geth
 
       - name: Push base images
         run: docker compose -f docker-compose.yml -f docker-compose.ci.yml push op-move geth

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.op-move
+      args:
+        - RUST_TOOLCHAIN
     environment:
       OP_MOVE_AUTH_JWT_SECRET: "f3099a1d969c4f5aba1a94434c368a84f8d950121feb4a398a67f78453853d1d"
       OP_MOVE_DB_PURGE: ${OP_MOVE_DB_PURGE:-false}

--- a/docker/Dockerfile.op-move
+++ b/docker/Dockerfile.op-move
@@ -1,5 +1,10 @@
-FROM rust:1.88-alpine AS build
+# Declare variable for Rust toolchain version which should be filled with `rust-toolchain` file contents
+ARG RUST_TOOLCHAIN="1.85.1"
 
+# Start from a container that has workspace rust toolchain
+FROM rust:${RUST_TOOLCHAIN}-alpine AS build
+
+# Set working directory
 WORKDIR /volume
 
 # Copy file with workspace rust toolchain


### PR DESCRIPTION
### Description
The docker image toolchain and the workspace toolchain versions should match. If they won't then the workspace toolchain gets downloaded. It is then stored next to the image toolchain that won't get used at all.

### Changes
- Start from the workspace rust toolchain for `op-move`

### Testing
```
docker compose build
```
