### PR TITLE
build(docker): Upgrade `geth` version `1.14.5` => `1.14.6`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Build and install the Ethereum L1 runner from the [`geth` project](https://githu
 ```bash
 git clone https://github.com/ethereum/go-ethereum.git
 cd go-ethereum
-git checkout tags/v1.14.5 # or higher
+git checkout tags/v1.14.6 # or higher
 make geth
 mv build/bin/geth ~/go/bin/geth
 ```
@@ -44,8 +44,9 @@ mv build/bin/geth ~/go/bin/geth
 
 ### Go-Ethereum version
 
-Make sure the `geth` version is compatible. Otherwise, the API communication could fail. The best way to match the versions is to check out a `go-ethereum` `tag` around the day of the `optimism` commit in submodule.
-For instance, a compatible `geth` tag is `tags/v1.14.5` for the current `optimism` version.
+Make sure the `geth` version is compatible. Otherwise, the API communication could fail. The best way to match the
+versions is to check out a `go-ethereum` `tag` around the day of the `optimism` commit in submodule.
+For instance, a compatible `geth` tag is `tags/v1.14.6` for the current `optimism` version.
 To check which commit we use for Optimism:
 
 ```bash

--- a/docker/Dockerfile.geth
+++ b/docker/Dockerfile.geth
@@ -26,8 +26,7 @@ RUN \
   # Clean up
   && rm -rf /tmp/* \
   # Clone geth sources
-  && git clone https://github.com/ethereum/go-ethereum . \
-  && git checkout v1.14.5
+  && git clone https://github.com/ethereum/go-ethereum . --branch v1.14.6 --depth 1
 
 # Install go
 COPY --from=golang:1.22-alpine /usr/local/go/ /usr/local/go/


### PR DESCRIPTION
### Description
Brings in this fix ethereum/go-ethereum#29955

Which is needed for proper restartability of the `geth` container.

### Changes
- Upgrade `geth` version `1.14.5` => `1.14.6`
- Clone directly with a tag and minimal depth to decrease space usage of the `.git` directory

### Testing
```
docker compose build
```
