### PR TITLE
build(docker): Initialize geth during image build

### DIFF
--- a/docker/Dockerfile.geth
+++ b/docker/Dockerfile.geth
@@ -56,14 +56,38 @@ RUN \
 COPY --from=build /volume/build/bin/geth /usr/local/bin/geth
 COPY --from=foundry /cast /usr/local/bin/cast
 COPY --from=foundry /forge /usr/local/bin/forge
-COPY docker/wait-for-it.sh /usr/local/bin/wait-for-it
-COPY docker/prefund.sh prefund.sh
-COPY .env .env
-COPY docker/geth.sh entrypoint.sh
-COPY docker/keystore.sh keystore.sh
-COPY docker/geth-init.sh geth-init.sh
+COPY --chmod=0777 docker/wait-for-it.sh /usr/local/bin/wait-for-it
+COPY --chmod=0777 docker/prefund.sh prefund.sh
+COPY --chmod=0777 .env .env
+COPY --chmod=0777 docker/geth.sh entrypoint.sh
+COPY --chmod=0777 docker/keystore.sh keystore.sh
+COPY --chmod=0777 docker/geth-init.sh geth-init.sh
 
-# Set entrypoint to geth binary
-RUN chmod +x entrypoint.sh /usr/local/bin/wait-for-it prefund.sh keystore.sh geth-init.sh
+RUN \
+  # Create datadir for geth
+  mkdir -p ./l1_datadir \
+  # Initialize keystore in the datadir
+  && ./keystore.sh \
+  # Launch geth node to receive transactions
+  && geth \
+  --dev \
+  --dev.period 3 \
+  --datadir "./l1_datadir" \
+  --rpc.allow-unprotected-txs \
+  --http \
+  --http.addr 0.0.0.0 \
+  --http.port 58138 \
+  --http.corsdomain '*' \
+  --http.api 'web3,debug,eth,txpool,net,engine' \
+  --http.vhosts '*' \
+  # Store geth process ID
+  & GETH_PID=$! \
+  # Send transactions that prefund accounts and deploy Optimism factory deployer
+  && ./geth-init.sh \
+  # Send interrupt signal to geth to shut it down gracefully preventing datadir corruption
+  && kill -SIGINT "${GETH_PID}" \
+  # Wait for geth to exit
+  && wait "${GETH_PID}"
 
+# Set entrypoint to a script that launches geth
 ENTRYPOINT [ "/volume/entrypoint.sh" ]

--- a/docker/Dockerfile.op-move
+++ b/docker/Dockerfile.op-move
@@ -2,7 +2,7 @@
 ARG RUST_TOOLCHAIN="1.85.1"
 
 # Start from a container that has workspace rust toolchain
-FROM rust:${RUST_TOOLCHAIN}-alpine AS build
+FROM rust:${RUST_TOOLCHAIN}-alpine3.21 AS build
 
 # Set working directory
 WORKDIR /volume
@@ -20,7 +20,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 COPY . .
 
 # RocksDB breaks the build with libclang.so not found, point its location explicitly
-ENV LIBCLANG_PATH="/usr/lib/llvm20/lib/libclang.so.20.1.8"
+ENV LIBCLANG_PATH="/usr/lib/libclang.so"
 
 # Build release binary
 RUN --mount=type=cache,target=/root/.cargo/registry \

--- a/docker/geth-init.sh
+++ b/docker/geth-init.sh
@@ -14,4 +14,4 @@ wait-for-it "${L1_RPC_ADDR}:${L1_RPC_PORT}"
 ./prefund.sh
 
 # Deploy Optimism factory deployer contract
-cast publish --async --rpc-url "${L1_RPC_URL}" "${SIGNED_L1_CONTRACT_TX}"
+cast publish --rpc-url "${L1_RPC_URL}" "${SIGNED_L1_CONTRACT_TX}"

--- a/docker/geth.sh
+++ b/docker/geth.sh
@@ -7,13 +7,6 @@
 set -eux
 L1_DATADIR="./l1_datadir"
 
-# In case of restart, data dir will not be empty
-# Wipe it to avoid an attempt to restore the state which is not persisted in `--dev` mode
-rm -rf "${L1_DATADIR}" && mkdir -p "${L1_DATADIR}"
-
-./keystore.sh &
-./geth-init.sh &
-
 # Ephemeral proof-of-authority network with a pre-funded developer account,
 # with automatic mining when there are pending transactions.
 geth \
@@ -26,4 +19,20 @@ geth \
   --http.port 58138 \
   --http.corsdomain '*' \
   --http.api 'web3,debug,eth,txpool,net,engine' \
-  --http.vhosts '*'
+  --http.vhosts '*' &
+
+# Get the PID of the geth process launched in the background
+GETH_PID="$!"
+
+# Shuts geth down in a way that does not corrupt the datadir
+function shutdown() {
+  kill -SIGINT "${GETH_PID}"
+  wait "${GETH_PID}"
+  exit 0
+}
+
+# Trap signal from docker stop to the graceful shutdown function
+trap shutdown SIGTERM
+
+# Block on the background geth process
+wait "${GETH_PID}"


### PR DESCRIPTION
### Description
Runs the geth initialization during image build which includes:
* Initialize keystore for deterministic account addresses
* Prefund dev accounts
* Deploy Optimism factory deployer

It also brings:
* Graceful shutdown: When you stop the geth container, it actually propagates the SIGINT to the process and waits for it to properly finish.
* Restartability: Thanks to the graceful shutdown and #521 the container can be stopped and started again and will pickup exactly where it was stopped.
* Speed of docker operations: The geth container shutdown speed is now decreased from 10s to a couple of milliseconds. Mostly due to the fact that the interrupt signal reaches geth this time.

### Changes
- Launch geth during image build and run initialization transactions
- Implement graceful shutdown for the geth container

### Testing
```
docker compose build geth && docker compose up geth
```