### PR TITLE
build(docker): Wait for finalized block with positive timestamp during `geth` image build

### DIFF
--- a/docker/geth-init.sh
+++ b/docker/geth-init.sh
@@ -15,3 +15,6 @@ wait-for-it "${L1_RPC_ADDR}:${L1_RPC_PORT}"
 
 # Deploy Optimism factory deployer contract
 cast publish --rpc-url "${L1_RPC_URL}" "${SIGNED_L1_CONTRACT_TX}"
+
+# Wait for a finalized block with a positive timestamp
+while [ "$(cast block finalized --rpc-url "${L1_RPC_URL}" | awk '/^timestamp/ { print $2 }')" -le 0 ]; do sleep 3; done

--- a/docker/op-node.sh
+++ b/docker/op-node.sh
@@ -28,16 +28,6 @@ export DEPLOY_CONFIG_PATH="${DEPLOY_CONFIG}"
 if [ ! -f "${DEPLOY_CONFIG_PATH}" ]; then
   rm -f "${SHARED}/1337-deploy.json"
 
-  echo "Waiting for a finalized L1 block with a non-zero timestamp..."
-  timestamp=0
-  while [ "$timestamp" -le 0 ]; do
-    block_info=$(cast block finalized --rpc-url "$L1_RPC_URL" || echo "timestamp 0")
-    timestamp=$(echo "$block_info" | awk '/^timestamp/ { print $2 }')
-    echo "Waiting until finalized block timestamp > 0."
-    sleep 2
-  done
-  echo "L1 is fully ready with a valid block. Proceeding..."
-
   echo "Generating deploy config..."
   /volume/config.sh
 


### PR DESCRIPTION
### Description
Moves the logic responsible for waiting for a finalized block with a positive timestamp from `op-node` container entrypoint to `geth` image build.

### Changes
- Wait for finalized block with positive timestamp during `geth` image build
- Remove waiting for finalized block with positive timestamp from `op-node` entrypoint

### Testing
```
docker compose build
docker stack deploy -c docker-compose.yml umi
```