### PR TITLE
feat(server): expose prometheus endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2889,7 +2889,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "regex",
@@ -5810,6 +5810,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-util",
+ "rustls 0.23.27",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6035,7 +6052,7 @@ checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
 dependencies = [
  "bitmaps",
  "rand_core 0.6.4",
- "rand_xoshiro",
+ "rand_xoshiro 0.6.0",
  "sized-chunks",
  "typenum",
  "version_check",
@@ -6859,6 +6876,53 @@ dependencies = [
  "keccak",
  "rand_core 0.6.4",
  "zeroize",
+]
+
+[[package]]
+name = "metrics"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
+dependencies = [
+ "ahash 0.8.12",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "indexmap 2.9.0",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe8db7a05415d0f919ffb905afa37784f71901c9a773188876984b4f769ab986"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.3",
+ "metrics",
+ "quanta",
+ "rand 0.9.1",
+ "rand_xoshiro 0.7.0",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -9366,6 +9430,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "poseidon-ark"
 version = "0.0.1"
 source = "git+https://github.com/arnaucube/poseidon-ark.git?rev=6d2487aa1308d9d3860a2b724c485d73095c1c68#6d2487aa1308d9d3860a2b724c485d73095c1c68"
@@ -9653,7 +9723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.101",
@@ -9693,6 +9763,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -9924,6 +10009,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -11395,6 +11498,12 @@ dependencies = [
  "bitmaps",
  "typenum",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
@@ -12940,6 +13049,7 @@ dependencies = [
  "alloy-trie",
  "aptos-api-types",
  "bcs 0.1.3",
+ "metrics",
  "move-core-types 0.0.4 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.27.2)",
  "move-table-extension",
  "op-alloy",
@@ -12965,6 +13075,7 @@ dependencies = [
  "alloy",
  "alloy-trie",
  "aptos-api-types",
+ "metrics",
  "move-core-types 0.0.4 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.27.2)",
  "move-table-extension",
  "move-vm-runtime",
@@ -13139,6 +13250,8 @@ dependencies = [
  "hyper 0.14.32",
  "jsonwebtoken 9.3.1",
  "lazy_static",
+ "metrics",
+ "metrics-exporter-prometheus",
  "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.27.2)",
  "move-core-types 0.0.4 (git+https://github.com/aptos-labs/aptos-core?tag=aptos-node-v1.27.2)",
  "move-vm-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,21 @@
 [workspace]
 resolver = "3"
 members = [
-    "api",
-    "app",
-    "blockchain",
-    "evm-ext",
-    "execution",
-    "genesis",
-    "genesis-builder",
-    "genesis-image",
-    "server",
-    "server/args",
-    "shared",
-    "state",
-    "storage/rocksdb",
-    "storage/heed",
-    "trie",
+  "api",
+  "app",
+  "blockchain",
+  "evm-ext",
+  "execution",
+  "genesis",
+  "genesis-builder",
+  "genesis-image",
+  "server",
+  "server/args",
+  "shared",
+  "state",
+  "storage/rocksdb",
+  "storage/heed",
+  "trie",
 ]
 
 [workspace.package]
@@ -24,7 +24,14 @@ version = "0.1.0"
 edition = "2024"
 
 [workspace.dependencies]
-alloy = { version = "0.13", features = ["full", "genesis", "getrandom", "rlp", "serde", "signer-keystore"] }
+alloy = { version = "0.13", features = [
+  "full",
+  "genesis",
+  "getrandom",
+  "rlp",
+  "serde",
+  "signer-keystore",
+] }
 alloy-rlp = { version = "0.3", features = ["derive"] }
 alloy-trie = "0.7"
 anyhow = "1"
@@ -58,6 +65,8 @@ hex-literal = "0.4"
 hyper = "0.14"
 jsonwebtoken = { version = "9", default-features = false }
 lazy_static = "1.5"
+metrics = "0.24.2"
+metrics-exporter-prometheus = "0.17.2"
 move-binary-format = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.27.2" }
 move-bytecode-utils = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.27.2" }
 move-compiler = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.27.2" }
@@ -68,7 +77,9 @@ move-package = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.28
 move-resource-viewer = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.27.2" }
 move-table-extension = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.27.2" }
 move-vm-runtime = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.27.2" }
-move-vm-test-utils = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.27.2", features = ["table-extension"] }
+move-vm-test-utils = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.27.2", features = [
+  "table-extension",
+] }
 move-vm-types = { git = "https://github.com/aptos-labs/aptos-core", tag = "aptos-node-v1.27.2" }
 umi-api = { path = "api" }
 umi-app = { path = "app" }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -19,6 +19,7 @@ alloy.workspace = true
 aptos-api-types.workspace = true
 bcs.workspace = true
 alloy-trie.workspace = true
+metrics.workspace = true
 move-core-types.workspace = true
 move-table-extension.workspace = true
 umi-app.workspace = true

--- a/api/src/request.rs
+++ b/api/src/request.rs
@@ -4,6 +4,7 @@ use {
         jsonrpc::{JsonRpcError, JsonRpcResponse},
         method_name::MethodName,
     },
+    metrics::{counter, gauge, histogram},
     umi_app::{ApplicationReader, CommandQueue, Dependencies},
     umi_blockchain::payload::NewPayloadId,
 };
@@ -93,7 +94,13 @@ where
         return Err(JsonRpcError::missing_method(request));
     }
 
-    match method {
+    let method_str = format!("{method:?}");
+    let t0 = std::time::Instant::now();
+
+    counter!("rpc_requests_total", "method" => method_str.clone()).increment(1);
+    gauge!("rpc_inflight_requests", "method" => method_str.clone()).increment(1.0);
+
+    let resp = match method {
         ForkChoiceUpdatedV3 => {
             forkchoice_updated::execute_v3(request, queue, app, payload_id).await
         }
@@ -133,5 +140,16 @@ where
         // eth_accounts: Returns a list of addresses owned by client.
         // We do not support owning addresses in our client, so always return an empty list.
         Accounts => Ok(serde_json::Value::Array(Vec::new())),
-    }
+    };
+
+    gauge!("rpc_inflight_requests", "method" => method_str.clone()).decrement(1.0);
+    let _ = resp.as_ref().map_err(|e| {
+        let err_code = format!("{}", e.code);
+        counter!("rpc_errors_total", "method" => method_str.clone(), "code" => err_code)
+            .increment(1);
+    });
+    histogram!("rpc_request_duration_seconds", "method" => method_str)
+        .record(t0.elapsed().as_secs_f64());
+
+    resp
 }

--- a/api/src/request.rs
+++ b/api/src/request.rs
@@ -85,16 +85,16 @@ where
         payload_id,
         serialization_tag,
     } = modifiers;
-    let method: MethodName = json_utils::get_field(&request, "method")
+    let method_str = json_utils::get_field(&request, "method")
         .as_str()
         .ok_or(JsonRpcError::missing_method(request.clone()))?
-        .parse()?;
+        .to_owned();
+    let method: MethodName = method_str.parse()?;
 
     if !is_allowed(&method) {
         return Err(JsonRpcError::missing_method(request));
     }
 
-    let method_str = format!("{method:?}");
     let t0 = std::time::Instant::now();
 
     counter!("rpc_requests_total", "method" => method_str.clone()).increment(1);

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 alloy.workspace = true
 alloy-trie.workspace = true
 aptos-api-types.workspace = true
+metrics.workspace = true
 move-core-types.workspace = true
 move-table-extension.workspace = true
 move-vm-runtime.workspace = true

--- a/app/src/command.rs
+++ b/app/src/command.rs
@@ -5,6 +5,7 @@ use {
         input::{WithExecutionOutcome, WithPayloadAttributes},
     },
     alloy::{consensus::Receipt, primitives::Bloom, rlp::Encodable},
+    metrics::histogram,
     umi_blockchain::{
         block::{BaseGasFee, Block, BlockHash, BlockRepository, ExtendedBlock, Header},
         payload::{PayloadId, PayloadQueries},
@@ -34,6 +35,8 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
         attributes: PayloadForExecution,
         id: PayloadId,
     ) -> Result<(), UnrecoverableAppFailure> {
+        let t0 = std::time::Instant::now();
+
         let payload_exists = self
             .payload_queries
             .by_id(&self.storage_reader, id)
@@ -278,6 +281,8 @@ impl<'app, D: Dependencies<'app>> Application<'app, D> {
         }
 
         in_progress_payloads.finish_id(block, executed_transactions.into_iter().map(Into::into));
+
+        histogram!("block_build_duration_seconds").record(t0.elapsed().as_secs_f64());
 
         Ok(())
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - ./docker/op-move/volume:/volume/db
     ports:
       - "8545:8545"
+      - "9000:9000"
     deploy:
       replicas: 1
       update_config:

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -51,6 +51,8 @@ tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 warp.workspace = true
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,4 +1,5 @@
 use {
+    metrics_exporter_prometheus::PrometheusBuilder,
     umi_server::{defaults, ServerRuntimes},
     umi_server_args::{CliLayer, ConfigBuilder, EnvLayer, FileLayer},
 };
@@ -11,6 +12,11 @@ fn main() {
         .layer(CliLayer::new())
         .try_build()
         .expect("Must build config to run app");
+
+    PrometheusBuilder::new()
+        .with_http_listener(([0, 0, 0, 0], 9000))
+        .install()
+        .expect("Must have Prometheus sink installed");
 
     umi_server::set_global_tracing_subscriber();
 


### PR DESCRIPTION
### Description
<!-- What does this PR do? -->
Exposes a scraping endpoint for metrics and instruments RPC request handling.
<!-- Fixes #123 -->

### Changes
<!-- Key changes -->
- Handler installation in main
- Metrics calls in API for RPC and in app for block build

### Testing
<!-- How was it tested? -->
Just `cargo check`. Will try to run it on a local stack later.

### Notes
<!-- Additional info -->
An alternative route was to make the endpoint available via warp, but this change was more minimal (as e.g. that would need different headers).

Besides the work here, I'll need to setup the so-called [Op Agent](https://cloud.google.com/monitoring/agent/ops-agent/prometheus) in GCP and restart the devnet, and hopefully we'll be able to see the new metrics in the [dashboard](https://console.cloud.google.com/monitoring/metrics-explorer;duration=P7D?hl=en&project=blockchain-451501) immediately after.