### PR TITLE
build(docker): Remove dependency on `jq` from `op-proposer`

### DIFF
--- a/docker/op-proposer/entrypoint.sh
+++ b/docker/op-proposer/entrypoint.sh
@@ -13,7 +13,7 @@ wait-for-it -t "${TIMEOUT_SECS}" "$(echo ${L1_RPC_URL} | cut -c 8-)"
 wait-for-it -t "${TIMEOUT_SECS}" "$(echo ${ROLLUP_RPC_URL} | cut -c 8-)"
 
 # Read the oracle address from the list of deployed contract addresses
-L2_ORACLE_PROXY=$(jq -r .L2OutputOracleProxy "${L1_DEPLOYMENT}")
+L2_ORACLE_PROXY=$(grep L2OutputOracleProxy "${L1_DEPLOYMENT}" | cut -d"\"" -f4)
 
 op-proposer \
     --poll-interval 12s \

--- a/docker/shared/Dockerfile
+++ b/docker/shared/Dockerfile
@@ -61,8 +61,7 @@ WORKDIR /volume
 
 RUN \
   # bash required by wait-for-it
-  # jq required by entrypoint to parse L2_ORACLE_PROXY
-  apk add --no-cache bash jq \
+  apk add --no-cache bash \
   # Clean up
   && rm -rf /tmp/* /var/cache/apk/*
 


### PR DESCRIPTION
### Description
Removes `jq` and uses grep + cut instead. Saves one dependency install during build and about 2 MB from the final image size.

### Changes
- Remove `jq`
- Parse using grep + cut

### Testing
```
docker compose build
```