### PR TITLE
build(docker): Add configurable parameters for L1 and L2 block times

### DIFF
--- a/.env
+++ b/.env
@@ -17,3 +17,9 @@ SEQUENCER_PRIVATE_KEY=0x66fe1b9d3babc69ad68fad96ac55b08f8d0ab3cb404c78538c0a9616
 
 # RPC URL for the L1 network to interact with
 L1_RPC_URL=http://127.0.0.1:58138
+
+# L1 block production period in seconds
+L1_BLOCK_TIME=12
+
+# L2 block production period in seconds
+L2_BLOCK_TIME=2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,8 @@ services:
       - ./docker/shared/volume:/volume/shared
     ports:
       - "58138:58138"
+    env_file:
+      - .env
 
 networks:
   localnet:

--- a/docker/geth/entrypoint.sh
+++ b/docker/geth/entrypoint.sh
@@ -15,7 +15,7 @@ if [ -f "${INIT_OP}" ]; then ${INIT_OP} ; rm -f ${INIT_OP}; fi
 # with automatic mining when there are pending transactions.
 geth \
   --dev \
-  --dev.period 3 \
+  --dev.period "${L1_BLOCK_TIME}" \
   --datadir "${L1_DATADIR}" \
   --rpc.allow-unprotected-txs \
   --http \

--- a/server/src/tests/config.sh
+++ b/server/src/tests/config.sh
@@ -21,8 +21,8 @@ config=$(cat << EOL
 
   "l1ChainID": 1337,
   "l2ChainID": 42069,
-  "l2BlockTime": 1,
-  "l1BlockTime": 2,
+  "l2BlockTime": $L2_BLOCK_TIME,
+  "l1BlockTime": $L1_BLOCK_TIME,
 
   "maxSequencerDrift": 600,
   "sequencerWindowSize": 3600,


### PR DESCRIPTION
### Description
Adds configurable parameters for L1 and L2 block times.

The block times are applied in `geth` entrypoint. The L1 block time is used as `--dev.period` (post L2 deployment).

Both block times are a part of L2 genesis config.

### Changes
- Add `L1_BLOCK_TIME` env var to `.env`
- Add `L2_BLOCK_TIME` env var to `.env`
- Propagate the above mentioned env vars to geth entrypoint.

### Testing
Using docker

### Notes
Closes #544 